### PR TITLE
feat: revamp dashboard summary layout

### DIFF
--- a/src/components/dashboard/IncidentBanner.tsx
+++ b/src/components/dashboard/IncidentBanner.tsx
@@ -1,0 +1,42 @@
+import { BadgeCheck, TriangleAlert } from "lucide-react";
+import { ReactNode } from "react";
+
+export type IncidentBannerProps = {
+  incidentCount: number;
+  windowSize: number;
+  onClick?: () => void;
+  actionSlot?: ReactNode;
+};
+
+export function IncidentBanner({
+  incidentCount,
+  windowSize,
+  onClick,
+  actionSlot,
+}: IncidentBannerProps) {
+  if (incidentCount === 0) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex w-full items-center justify-between rounded-xl border border-amber-300/70 bg-amber-50/80 p-4 text-left shadow-sm transition hover:border-amber-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+    >
+      <div className="flex items-center gap-3">
+        <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-amber-100 text-amber-700">
+          <TriangleAlert className="h-5 w-5" />
+        </span>
+        <div>
+          <p className="text-sm font-semibold text-amber-800">Инциденты: {incidentCount}</p>
+          <p className="text-xs text-amber-700/80">
+            Найдено {incidentCount} событий с предупреждениями за последние {windowSize} записей.
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center gap-3">
+        {actionSlot}
+        <BadgeCheck className="h-5 w-5 text-amber-600" />
+      </div>
+    </button>
+  );
+}

--- a/src/components/dashboard/LatencyChart.tsx
+++ b/src/components/dashboard/LatencyChart.tsx
@@ -1,0 +1,26 @@
+import type { ChartPoint } from "@/utils/stats";
+import { TimeseriesChart, type TimeseriesChartProps } from "./TimeseriesChart";
+
+export type LatencyChartProps = {
+  data: ChartPoint[];
+  label?: string;
+  valueFormatter?: TimeseriesChartProps["valueFormatter"];
+  tooltipFormatter?: TimeseriesChartProps["tooltipFormatter"];
+};
+
+export function LatencyChart({
+  data,
+  label = "Латентность",
+  valueFormatter,
+  tooltipFormatter,
+}: LatencyChartProps) {
+  return (
+    <TimeseriesChart
+      data={data}
+      color="#0f172a"
+      label={label}
+      valueFormatter={valueFormatter}
+      tooltipFormatter={tooltipFormatter}
+    />
+  );
+}

--- a/src/components/dashboard/LogDetailsDrawer.tsx
+++ b/src/components/dashboard/LogDetailsDrawer.tsx
@@ -1,0 +1,109 @@
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis } from "recharts";
+import type { LogRecord } from "@/utils/stats";
+
+export type LogDetailsDrawerProps = {
+  log: LogRecord | null;
+  open: boolean;
+  onClose: () => void;
+  latencyTrend: { timestamp: number; value: number }[];
+  pingTrend: { timestamp: number; value: number }[];
+};
+
+const DrawerContent = ({
+  log,
+  onClose,
+  latencyTrend,
+  pingTrend,
+}: Pick<LogDetailsDrawerProps, "log" | "onClose" | "latencyTrend" | "pingTrend">) => {
+  if (!log) return null;
+
+  return (
+    <div className="pointer-events-auto ml-auto flex h-full w-full max-w-xl flex-col border-l border-slate-200 bg-white shadow-xl">
+      <div className="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+        <div>
+          <h2 className="text-base font-semibold text-slate-900">Детали проверки</h2>
+          <p className="text-xs text-slate-500">{new Date(log.timestamp).toLocaleString()}</p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-full p-2 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto px-6 py-4">
+        <div className="space-y-4">
+          <div>
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Статистика</h3>
+            <div className="mt-3 grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="rounded-xl border border-slate-200/70 p-3">
+                <p className="text-xs font-medium text-slate-500">Латентность</p>
+                <div className="mt-2 h-32">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <LineChart data={latencyTrend} margin={{ top: 8, right: 12, left: -16, bottom: 0 }}>
+                      <XAxis dataKey="timestamp" hide type="number" domain={["auto", "auto"]} />
+                      <Tooltip
+                        labelFormatter={(value) => new Date(value).toLocaleTimeString()}
+                        formatter={(value: number) => [`${value} мс`, "Латентность"]}
+                      />
+                      <Line type="monotone" dataKey="value" stroke="#0f172a" strokeWidth={2} dot={false} isAnimationActive={false} />
+                    </LineChart>
+                  </ResponsiveContainer>
+                </div>
+              </div>
+              <div className="rounded-xl border border-slate-200/70 p-3">
+                <p className="text-xs font-medium text-slate-500">Пинг</p>
+                <div className="mt-2 h-32">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <LineChart data={pingTrend} margin={{ top: 8, right: 12, left: -16, bottom: 0 }}>
+                      <XAxis dataKey="timestamp" hide type="number" domain={["auto", "auto"]} />
+                      <Tooltip
+                        labelFormatter={(value) => new Date(value).toLocaleTimeString()}
+                        formatter={(value: number) => [`${value} мс`, "Пинг"]}
+                      />
+                      <Line type="monotone" dataKey="value" stroke="#2563eb" strokeWidth={2} dot={false} isAnimationActive={false} />
+                    </LineChart>
+                  </ResponsiveContainer>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div>
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">JSON</h3>
+            <pre className="mt-2 overflow-x-auto rounded-xl border border-slate-200/70 bg-slate-950/95 p-4 text-xs text-slate-200">
+              {JSON.stringify(log, null, 2)}
+            </pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export function LogDetailsDrawer({ log, open, onClose, latencyTrend, pingTrend }: LogDetailsDrawerProps) {
+  useEffect(() => {
+    if (open) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex bg-slate-950/40 backdrop-blur-sm" onClick={onClose}>
+      <div className="pointer-events-none flex h-full w-full" onClick={(event) => event.stopPropagation()}>
+        <DrawerContent log={log} onClose={onClose} latencyTrend={latencyTrend} pingTrend={pingTrend} />
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/dashboard/LogsTable.tsx
+++ b/src/components/dashboard/LogsTable.tsx
@@ -1,0 +1,273 @@
+import {
+  memo,
+  useCallback,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+  type UIEvent,
+} from "react";
+import type { LogRecord, TrafficLight } from "@/utils/stats";
+
+export type LogsTableFilters = {
+  traffic: Set<TrafficLight>;
+  statusRange: { min: number; max: number };
+  search: string;
+  limit: number;
+};
+
+export type LogsTableProps = {
+  logs: LogRecord[];
+  onRowClick: (log: LogRecord) => void;
+  filters: LogsTableFilters;
+  onToggleTraffic: (traffic: TrafficLight) => void;
+  onStatusChange: (range: { min: number; max: number }) => void;
+  onSearchChange: (value: string) => void;
+  onLimitChange: (value: number) => void;
+};
+
+const TRAFFIC_ORDER: TrafficLight[] = ["green", "orange", "red"];
+const TRAFFIC_LABELS: Record<TrafficLight, string> = {
+  green: "зелёный",
+  orange: "оранжевый",
+  red: "красный",
+};
+
+const TRAFFIC_COLOR: Record<TrafficLight, string> = {
+  green: "bg-emerald-400",
+  orange: "bg-amber-400",
+  red: "bg-rose-400",
+};
+
+const LIMIT_OPTIONS = [100, 500, 1000];
+
+const GRID_TEMPLATE =
+  "minmax(200px, 1.4fr) minmax(120px, 0.8fr) minmax(80px, 0.6fr) repeat(2, minmax(90px, 0.7fr)) minmax(110px, 0.8fr) minmax(90px, 0.7fr) minmax(110px, 0.7fr)";
+
+const LIST_HEIGHT = 420;
+const ROW_HEIGHT = 52;
+const OVERSCAN = 8;
+
+const HeaderCell = ({ children }: { children: ReactNode }) => (
+  <div className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500">{children}</div>
+);
+
+type LogRowProps = {
+  log: LogRecord;
+  onRowClick: (log: LogRecord) => void;
+  style?: CSSProperties;
+};
+
+const LogRow = memo(function LogRow({ log, onRowClick, style }: LogRowProps) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: GRID_TEMPLATE,
+        ...(style ?? {}),
+      }}
+      className="cursor-pointer border-b border-slate-100/70 bg-white px-4 text-xs text-slate-600 transition hover:bg-slate-50"
+      onClick={() => onRowClick(log)}
+    >
+      <div className="flex h-full items-center text-slate-500">
+        {new Date(log.timestamp).toLocaleString()}
+      </div>
+      <div className="flex h-full items-center gap-2 capitalize">
+        <span className={`h-2 w-2 rounded-full ${TRAFFIC_COLOR[log.traffic_light]}`} />
+        {log.traffic_light}
+      </div>
+      <div className="flex h-full items-center text-slate-700">{log.http_status ?? "—"}</div>
+      <div className="flex h-full items-center text-slate-700">{log.latency_ms ?? "—"}</div>
+      <div className="flex h-full items-center text-slate-700">{log.ping_ms ?? "—"}</div>
+      <div className="flex h-full items-center text-slate-700">{log.ssl_days_left ?? "—"}</div>
+      <div className="flex h-full items-center text-slate-700">{log.dns_resolved ? "yes" : "no"}</div>
+      <div className="flex h-full items-center text-slate-700">{log.redirects ?? "—"}</div>
+    </div>
+  );
+});
+
+const rowKey = (log: LogRecord, index: number) =>
+  `${log.timestamp ?? index}-${log.url ?? ""}-${log.http_status ?? ""}-${log.traffic_light}`;
+
+const RegularRows = memo(function RegularRows({
+  logs,
+  onRowClick,
+}: {
+  logs: LogRecord[];
+  onRowClick: (log: LogRecord) => void;
+}) {
+  return (
+    <div className="max-h-[420px] overflow-y-auto">
+      {logs.map((log, index) => (
+        <LogRow key={rowKey(log, index)} log={log} onRowClick={onRowClick} />
+      ))}
+    </div>
+  );
+});
+
+const VirtualizedRows = memo(function VirtualizedRows({
+  logs,
+  onRowClick,
+}: {
+  logs: LogRecord[];
+  onRowClick: (log: LogRecord) => void;
+}) {
+  const [scrollTop, setScrollTop] = useState(0);
+
+  const handleScroll = useCallback((event: UIEvent<HTMLDivElement>) => {
+    setScrollTop(event.currentTarget.scrollTop);
+  }, []);
+
+  const { start, end } = useMemo(() => {
+    const startIndex = Math.max(0, Math.floor(scrollTop / ROW_HEIGHT) - OVERSCAN);
+    const endIndex = Math.min(
+      logs.length,
+      Math.ceil((scrollTop + LIST_HEIGHT) / ROW_HEIGHT) + OVERSCAN,
+    );
+
+    return { start: startIndex, end: endIndex };
+  }, [logs.length, scrollTop]);
+
+  const visibleLogs = useMemo(() => logs.slice(start, end), [logs, start, end]);
+
+  return (
+    <div className="max-h-[420px] overflow-y-auto" onScroll={handleScroll}>
+      <div style={{ height: logs.length * ROW_HEIGHT, position: "relative" }}>
+        <div
+          style={{
+            position: "absolute",
+            top: start * ROW_HEIGHT,
+            left: 0,
+            right: 0,
+          }}
+        >
+          {visibleLogs.map((log, index) => (
+            <LogRow
+              key={rowKey(log, start + index)}
+              log={log}
+              onRowClick={onRowClick}
+              style={{ height: ROW_HEIGHT }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+});
+
+export const LogsTable = memo(function LogsTable({
+  logs,
+  onRowClick,
+  filters,
+  onToggleTraffic,
+  onStatusChange,
+  onSearchChange,
+  onLimitChange,
+}: LogsTableProps) {
+  const isVirtualized = logs.length > 1000;
+
+  return (
+    <div className="flex flex-col gap-4 rounded-2xl border border-slate-200/60 bg-white/85 p-4 shadow-sm backdrop-blur">
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-4">
+        <div className="flex flex-wrap gap-2">
+          {TRAFFIC_ORDER.map((item) => {
+            const active = filters.traffic.has(item);
+            return (
+              <button
+                key={item}
+                type="button"
+                onClick={() => onToggleTraffic(item)}
+                className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs capitalize transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 ${
+                  active
+                    ? "border-slate-900 bg-slate-900 text-white"
+                    : "border-slate-200 bg-white text-slate-600"
+                }`}
+              >
+                <span className={`h-2 w-2 rounded-full ${TRAFFIC_COLOR[item]}`} />
+                {TRAFFIC_LABELS[item]}
+              </button>
+            );
+          })}
+        </div>
+        <div className="flex flex-col gap-1 text-xs text-slate-500">
+          <span className="font-medium text-slate-600">HTTP статус</span>
+          <div className="flex items-center gap-2">
+            <input
+              type="number"
+              min={100}
+              max={filters.statusRange.max}
+              value={filters.statusRange.min}
+              onChange={(event) =>
+                onStatusChange({ min: Number(event.target.value), max: filters.statusRange.max })
+              }
+              className="h-8 w-20 rounded-md border border-slate-200 bg-white px-2 text-slate-600 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300"
+            />
+            <span>—</span>
+            <input
+              type="number"
+              min={filters.statusRange.min}
+              max={599}
+              value={filters.statusRange.max}
+              onChange={(event) =>
+                onStatusChange({ min: filters.statusRange.min, max: Number(event.target.value) })
+              }
+              className="h-8 w-20 rounded-md border border-slate-200 bg-white px-2 text-slate-600 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300"
+            />
+          </div>
+        </div>
+        <div className="flex flex-col gap-1 text-xs text-slate-500">
+          <span className="font-medium text-slate-600">Поиск по URL</span>
+          <input
+            type="search"
+            value={filters.search}
+            onChange={(event) => onSearchChange(event.target.value)}
+            placeholder="Введите часть адреса"
+            className="h-8 rounded-md border border-slate-200 bg-white px-3 text-slate-600 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300"
+          />
+        </div>
+        <div className="flex flex-col gap-1 text-xs text-slate-500">
+          <span className="font-medium text-slate-600">Лимит записей</span>
+          <div className="flex items-center gap-2">
+            {LIMIT_OPTIONS.map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => onLimitChange(option)}
+                className={`h-8 w-12 rounded-md border text-xs font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300 ${
+                  filters.limit === option
+                    ? "border-slate-900 bg-slate-900 text-white"
+                    : "border-slate-200 bg-white text-slate-600"
+                }`}
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-slate-200/70">
+        <div className="min-w-[960px]">
+          <div
+            className="sticky top-0 z-10 grid bg-white/95 text-left"
+            style={{ gridTemplateColumns: GRID_TEMPLATE }}
+          >
+            <HeaderCell>Время</HeaderCell>
+            <HeaderCell>Статус</HeaderCell>
+            <HeaderCell>HTTP</HeaderCell>
+            <HeaderCell>Латентность</HeaderCell>
+            <HeaderCell>Пинг</HeaderCell>
+            <HeaderCell>SSL (дн.)</HeaderCell>
+            <HeaderCell>DNS</HeaderCell>
+            <HeaderCell>Редиректы</HeaderCell>
+          </div>
+          {isVirtualized ? (
+            <VirtualizedRows logs={logs} onRowClick={onRowClick} />
+          ) : (
+            <RegularRows logs={logs} onRowClick={onRowClick} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/src/components/dashboard/MetricCard.tsx
+++ b/src/components/dashboard/MetricCard.tsx
@@ -1,0 +1,67 @@
+import { ReactNode } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis } from "recharts";
+
+export type MetricCardProps = {
+  title: string;
+  value: ReactNode;
+  description?: string;
+  trend?: { timestamp: number; value: number }[];
+  accent?: "default" | "warning" | "danger";
+  compact?: boolean;
+  trendFormatter?: (value: number) => string;
+};
+
+const ACCENTS: Record<NonNullable<MetricCardProps["accent"]>, string> = {
+  default: "border-slate-200/60 bg-white/80",
+  warning: "border-amber-300/70 bg-amber-50/70",
+  danger: "border-rose-300/70 bg-rose-50/70",
+};
+
+export function MetricCard({
+  title,
+  value,
+  description,
+  trend,
+  accent = "default",
+  compact = false,
+  trendFormatter,
+}: MetricCardProps) {
+  return (
+    <Card
+      className={`flex h-full flex-col justify-between border ${ACCENTS[accent]} backdrop-blur-sm shadow-none`}
+    >
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium text-slate-600">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="text-3xl font-semibold text-slate-900">{value}</div>
+        {description ? (
+          <p className="text-xs text-slate-500">{description}</p>
+        ) : null}
+        {trend && trend.length > 1 ? (
+          <div className={`h-14 w-full ${compact ? "mt-1" : "mt-2"}`}>
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={trend} margin={{ top: 4, left: 0, right: 0, bottom: 0 }}>
+                <XAxis dataKey="timestamp" hide type="number" domain={['auto', 'auto']} />
+                <Tooltip
+                  wrapperClassName="!bg-slate-900/90 !text-white"
+                  labelFormatter={(value) => new Date(value).toLocaleTimeString()}
+                  formatter={(value: number) => [trendFormatter ? trendFormatter(value) : `${value.toFixed(0)} мс`, ""]}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="value"
+                  stroke="#1d4ed8"
+                  strokeWidth={2}
+                  dot={false}
+                  isAnimationActive={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/PingChart.tsx
+++ b/src/components/dashboard/PingChart.tsx
@@ -1,0 +1,26 @@
+import type { ChartPoint } from "@/utils/stats";
+import { TimeseriesChart, type TimeseriesChartProps } from "./TimeseriesChart";
+
+export type PingChartProps = {
+  data: ChartPoint[];
+  label?: string;
+  valueFormatter?: TimeseriesChartProps["valueFormatter"];
+  tooltipFormatter?: TimeseriesChartProps["tooltipFormatter"];
+};
+
+export function PingChart({
+  data,
+  label = "Пинг",
+  valueFormatter,
+  tooltipFormatter,
+}: PingChartProps) {
+  return (
+    <TimeseriesChart
+      data={data}
+      color="#2563eb"
+      label={label}
+      valueFormatter={valueFormatter}
+      tooltipFormatter={tooltipFormatter}
+    />
+  );
+}

--- a/src/components/dashboard/TimeseriesChart.tsx
+++ b/src/components/dashboard/TimeseriesChart.tsx
@@ -1,0 +1,95 @@
+import { memo } from "react";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { ChartPoint, LogRecord } from "@/utils/stats";
+
+export type TimeseriesChartProps = {
+  data: ChartPoint[];
+  color: string;
+  label: string;
+  valueFormatter?: (value: number) => string;
+  tooltipFormatter?: (meta: unknown, value: number) => string;
+};
+
+const formatTimestamp = (value: number) => {
+  const date = new Date(value);
+  return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+};
+
+const defaultValueFormatter = (value: number) => `${value} мс`;
+
+const isLogRecord = (value: unknown): value is LogRecord => {
+  return !!value && typeof value === "object" && "traffic_light" in value && "timestamp" in value;
+};
+
+const TimeseriesChartComponent = ({
+  data,
+  color,
+  label,
+  valueFormatter = defaultValueFormatter,
+  tooltipFormatter,
+}: TimeseriesChartProps) => {
+  return (
+    <div className="flex h-full flex-col gap-3 rounded-2xl border border-slate-200/60 bg-white/80 p-4 shadow-sm backdrop-blur">
+      <h3 className="text-sm font-semibold text-slate-600">{label}</h3>
+      <div className="h-64 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data} syncId="uptime-timeline" margin={{ top: 10, right: 16, left: 0, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+            <XAxis
+              dataKey="timestamp"
+              type="number"
+              domain={["auto", "auto"]}
+              tickFormatter={(value) => new Date(value).toLocaleTimeString()}
+              stroke="#94a3b8"
+              tick={{ fontSize: 12 }}
+            />
+            <YAxis stroke="#94a3b8" tick={{ fontSize: 12 }} width={70} />
+            <Tooltip
+              contentStyle={{ backgroundColor: "rgba(15, 23, 42, 0.9)", borderRadius: 12, border: "none" }}
+              labelFormatter={formatTimestamp}
+              formatter={(value?: number, __?: string, item?) => {
+                const meta = item?.payload?.meta as unknown;
+                if (typeof value !== "number") return ["", ""];
+                if (tooltipFormatter) {
+                  return [tooltipFormatter(meta, value), ""];
+                }
+                if (isLogRecord(meta)) {
+                  return [
+                    `${label}: ${valueFormatter(value)}` +
+                      `\nHTTP: ${meta.http_status ?? "—"}` +
+                      `\nTraffic: ${meta.traffic_light}` +
+                      `\nLatency: ${meta.latency_ms ?? "—"} мс` +
+                      `\nPing: ${meta.ping_ms ?? "—"} мс` +
+                      `\nSSL: ${meta.ssl_days_left ?? "—"} дн.` +
+                      `\nRedirects: ${meta.redirects ?? "—"}` +
+                      `\nDNS: ${meta.dns_resolved ? "ok" : "fail"}`,
+                    "",
+                  ];
+                }
+                return [`${label}: ${valueFormatter(value)}`, ""];
+              }}
+            />
+            <Line
+              type="monotone"
+              dataKey="value"
+              stroke={color}
+              strokeWidth={2}
+              dot={false}
+              isAnimationActive={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+};
+
+export const TimeseriesChart = memo(TimeseriesChartComponent);

--- a/src/components/dashboard/TrafficLightPie.tsx
+++ b/src/components/dashboard/TrafficLightPie.tsx
@@ -1,0 +1,71 @@
+import { Pie, PieChart, ResponsiveContainer, Tooltip, Cell } from "recharts";
+import type { TrafficLightAggregate } from "@/utils/stats";
+
+const COLORS = {
+  green: "#22c55e",
+  orange: "#f97316",
+  red: "#ef4444",
+};
+
+export type TrafficLightPieProps = {
+  data: TrafficLightAggregate;
+  title?: string;
+};
+
+export function TrafficLightPie({ data, title = "Статусы" }: TrafficLightPieProps) {
+  const transformed = Object.entries(data).map(([key, value]) => ({
+    name: key,
+    value,
+  }));
+
+  const total = transformed.reduce((sum, item) => sum + item.value, 0);
+
+  return (
+    <div className="flex h-full flex-col gap-3 rounded-2xl border border-slate-200/60 bg-white/80 p-4 shadow-sm backdrop-blur">
+      <h3 className="text-sm font-semibold text-slate-600">{title}</h3>
+      <div className="flex h-full flex-1 items-center justify-center">
+        <ResponsiveContainer width="100%" height={220}>
+          <PieChart>
+            <Pie
+              data={transformed}
+              dataKey="value"
+              nameKey="name"
+              innerRadius={60}
+              outerRadius={90}
+              paddingAngle={4}
+              stroke="#ffffff"
+              strokeWidth={2}
+              isAnimationActive={false}
+            >
+              {transformed.map((entry) => (
+                <Cell key={entry.name} fill={COLORS[entry.name as keyof typeof COLORS]} />
+              ))}
+            </Pie>
+            <Tooltip
+              formatter={(value: number, name: string) => {
+                const percentage = total === 0 ? 0 : ((value as number) / total) * 100;
+                return [`${value} • ${percentage.toFixed(1)}%`, name];
+              }}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+      <div className="grid grid-cols-3 gap-2 text-xs text-slate-500">
+        {transformed.map((entry) => {
+          const percentage = total === 0 ? 0 : ((entry.value ?? 0) / total) * 100;
+          return (
+            <div key={entry.name} className="flex items-center gap-2">
+              <span
+                className="h-2 w-2 rounded-full"
+                style={{ backgroundColor: COLORS[entry.name as keyof typeof COLORS] }}
+              />
+              <span className="capitalize">
+                {entry.name}: {percentage.toFixed(1)}%
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/TrafficLightTimeline.tsx
+++ b/src/components/dashboard/TrafficLightTimeline.tsx
@@ -1,0 +1,97 @@
+import { memo, useMemo } from "react";
+import { Area, AreaChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import type { TrafficLightTimeseriesPoint } from "@/utils/stats";
+
+export type TrafficLightTimelineProps = {
+  data: TrafficLightTimeseriesPoint[];
+  title?: string;
+};
+
+const COLORS = {
+  green: "#22c55e",
+  orange: "#f97316",
+  red: "#ef4444",
+};
+
+const formatTimestamp = (value: number) => {
+  const date = new Date(value);
+  return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+};
+
+export const TrafficLightTimeline = memo(function TrafficLightTimeline({
+  data,
+  title = "Распределение статусов",
+}: TrafficLightTimelineProps) {
+  const chartData = useMemo(() => {
+    return data.map((point) => {
+      const total = point.total || 1;
+      return {
+        timestamp: point.timestamp,
+        green: Number(((point.green / total) * 100).toFixed(2)),
+        orange: Number(((point.orange / total) * 100).toFixed(2)),
+        red: Number(((point.red / total) * 100).toFixed(2)),
+      };
+    });
+  }, [data]);
+
+  return (
+    <div className="flex h-full flex-col gap-3 rounded-2xl border border-slate-200/60 bg-white/80 p-4 shadow-sm backdrop-blur">
+      <h3 className="text-sm font-semibold text-slate-600">{title}</h3>
+      <div className="h-64 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart data={chartData} syncId="traffic-timeline" margin={{ top: 10, right: 16, left: 0, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+            <XAxis
+              dataKey="timestamp"
+              type="number"
+              domain={["auto", "auto"]}
+              tickFormatter={(value) => new Date(value).toLocaleTimeString()}
+              stroke="#94a3b8"
+              tick={{ fontSize: 12 }}
+            />
+            <YAxis
+              stroke="#94a3b8"
+              tick={{ fontSize: 12 }}
+              width={60}
+              domain={[0, 100]}
+              tickFormatter={(value) => `${value}%`}
+            />
+            <Tooltip
+              contentStyle={{ backgroundColor: "rgba(15, 23, 42, 0.9)", borderRadius: 12, border: "none" }}
+              labelFormatter={formatTimestamp}
+              formatter={(value: number, name: string) => [`${value.toFixed(1)}%`, name]}
+            />
+            <Legend formatter={(value) => value.toUpperCase()} iconType="circle" />
+            <Area
+              type="monotone"
+              dataKey="green"
+              stackId="traffic"
+              stroke={COLORS.green}
+              fill={COLORS.green}
+              fillOpacity={0.4}
+              isAnimationActive={false}
+            />
+            <Area
+              type="monotone"
+              dataKey="orange"
+              stackId="traffic"
+              stroke={COLORS.orange}
+              fill={COLORS.orange}
+              fillOpacity={0.4}
+              isAnimationActive={false}
+            />
+            <Area
+              type="monotone"
+              dataKey="red"
+              stackId="traffic"
+              stroke={COLORS.red}
+              fill={COLORS.red}
+              fillOpacity={0.4}
+              isAnimationActive={false}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+});

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,218 +1,730 @@
-import { useEffect, useState } from "react";
-import axios from "axios";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import axios, { CanceledError } from "axios";
 import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardContent,
-} from "@/components/ui/card";
+  aggregateTrafficLight,
+  buildAggregatedTimeseries,
+  buildTrafficLightTimeseries,
+  calcDnsSuccessRate,
+  calcUptime,
+  countIncidents,
+  getSparklineSeries,
+  mergeTrafficLightAggregates,
+  minSslDays,
+  summarizeAggregatedBuckets,
+  type AggregatedBucket,
+  type AggregatedDashboardResponse,
+  type ChartPoint,
+  type LogRecord,
+  type TrafficLight,
+} from "@/utils/stats";
+import { MetricCard } from "@/components/dashboard/MetricCard";
+import { TrafficLightPie } from "@/components/dashboard/TrafficLightPie";
+import { LatencyChart } from "@/components/dashboard/LatencyChart";
+import { PingChart } from "@/components/dashboard/PingChart";
+import { TimeseriesChart } from "@/components/dashboard/TimeseriesChart";
+import { TrafficLightTimeline } from "@/components/dashboard/TrafficLightTimeline";
 import {
-  Tabs,
-  TabsList,
-  TabsTrigger,
-  TabsContent,
-} from "@/components/ui/tabs";
-import {
-  LineChart,
-  Line,
-  XAxis,
-  YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  Legend,
-  PieChart,
-  Pie,
-  Cell,
-} from "recharts";
+  LogsTable,
+  type LogsTableFilters,
+} from "@/components/dashboard/LogsTable";
+import { LogDetailsDrawer } from "@/components/dashboard/LogDetailsDrawer";
+import { IncidentBanner } from "@/components/dashboard/IncidentBanner";
+import { RefreshCw } from "lucide-react";
 
-const API_URL = "http://localhost:8000"; // ⚡️ API сервис из docker-compose
+const API_URL = "http://localhost:8000";
+
+const TIME_RANGES = [
+  { value: "1s", label: "1 сек", durationMs: 1_000, groupBy: "1s" },
+  { value: "1m", label: "1 мин", durationMs: 60_000, groupBy: "1m" },
+  { value: "10m", label: "10 мин", durationMs: 600_000, groupBy: "10m" },
+  { value: "60m", label: "1 час", durationMs: 3_600_000, groupBy: "60m" },
+  { value: "1d", label: "1 день", durationMs: 86_400_000, groupBy: "1d" },
+  { value: "1w", label: "1 неделя", durationMs: 604_800_000, groupBy: "1w" },
+] as const;
+
+const DEFAULT_LIMIT = 500;
+const TRAFFIC_OPTIONS: TrafficLight[] = ["green", "orange", "red"];
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const isAggregatedBucket = (value: unknown): value is AggregatedBucket => {
+  return !!value && typeof value === "object" && "count" in value && "traffic_light" in value;
+};
+
+const aggregatedTooltip = (label: string, unit = "", digits = 0) => (meta: unknown, value: number) => {
+  const bucket = isAggregatedBucket(meta) ? meta : null;
+  const formatted = `${value.toFixed(digits)}${unit ? ` ${unit}` : ""}`;
+  const checks = bucket ? `\nПроверок: ${bucket.count}` : "";
+  return `${label}: ${formatted}${checks}`;
+};
+
+const buildTrend = (series: ChartPoint[], limit = 120) => {
+  return series.slice(-limit).map((point) => ({ timestamp: point.timestamp, value: point.value }));
+};
+
 
 type Site = {
-  url: string;
   name: string;
+  url: string;
 };
 
-type Log = {
-  timestamp: string;
-  traffic_light: string;
-  http_status: number | null;
-  latency_ms: number | null;
-  ping_ms: number | null;
-  ssl_days_left: number | null;
-  dns_resolved: number;
-  redirects: number | null;
-  errors_last: number | null;
+const getInitials = (site: Site) => {
+  if (site.name) {
+    return site.name
+      .split(" ")
+      .filter(Boolean)
+      .map((part) => part[0]?.toUpperCase())
+      .slice(0, 2)
+      .join("") || "?";
+  }
+  try {
+    const { hostname } = new URL(site.url);
+    return hostname
+      .split(".")
+      .filter(Boolean)
+      .map((part) => part[0]?.toUpperCase())
+      .slice(0, 2)
+      .join("") || "?";
+  } catch {
+    return "?";
+  }
 };
 
-const COLORS: Record<string, string> = {
-  green: "#22c55e",
-  orange: "#f97316",
-  red: "#ef4444",
+const getHostname = (site: Site) => {
+  try {
+    return new URL(site.url).hostname;
+  } catch {
+    return site.url;
+  }
 };
+
+const formatMs = (value: number | null) => (value === null ? "—" : `${Math.round(value)} мс`);
+const formatPercent = (value: number | null, digits = 1) =>
+  value === null ? "—" : `${value.toFixed(digits)}%`;
+const formatDays = (value: number | null, digits = 1) =>
+  value === null ? "—" : `${value.toFixed(digits)} дн.`;
+
 
 export default function DashboardPage() {
   const [sites, setSites] = useState<Site[]>([]);
-  const [selectedSite, setSelectedSite] = useState<string>("");
-  const [logs, setLogs] = useState<Log[]>([]);
+  const [selectedSiteUrl, setSelectedSiteUrl] = useState<string>("");
+  const [timeRange, setTimeRange] = useState<(typeof TIME_RANGES)[number]["value"]>("1m");
+  const [logs, setLogs] = useState<LogRecord[]>([]);
+  const [overview, setOverview] = useState<AggregatedDashboardResponse | null>(null);
+  const [siteAggregate, setSiteAggregate] = useState<AggregatedDashboardResponse | null>(null);
+  const [isOverviewLoading, setIsOverviewLoading] = useState(false);
+  const [isSiteLoading, setIsSiteLoading] = useState(false);
+  const [overviewError, setOverviewError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [autoRefreshEnabled, setAutoRefreshEnabled] = useState(true);
+  const [autoRefreshInterval, setAutoRefreshInterval] = useState(1);
+  const [trafficFilter, setTrafficFilter] = useState<Set<TrafficLight>>(new Set(TRAFFIC_OPTIONS));
+  const [httpStatusRange, setHttpStatusRange] = useState({ min: 100, max: 599 });
+  const [searchTerm, setSearchTerm] = useState("");
+  const [limit, setLimit] = useState(DEFAULT_LIMIT);
+  const [selectedLog, setSelectedLog] = useState<LogRecord | null>(null);
 
-  // Загружаем список сайтов
+  const timeRangeConfig = useMemo(
+    () => TIME_RANGES.find((option) => option.value === timeRange) ?? TIME_RANGES[1],
+    [timeRange],
+  );
+
   useEffect(() => {
-    axios.get(`${API_URL}/sites`).then((res) => {
-      setSites(res.data); // ✅ бекенд возвращает массив
-      if (res.data.length > 0) {
-        setSelectedSite(res.data[0].url);
-      }
-    });
-  }, []);
-
-  // 🔄 Автообновление логов каждую секунду
-  useEffect(() => {
-    if (!selectedSite) return;
-
-    const fetchLogs = async (siteUrl: string) => {
+    let isMounted = true;
+    const loadSites = async () => {
       try {
-        const res = await axios.get(`${API_URL}/logs`, {
-          params: { url: siteUrl, limit: 100 },
-        });
-        setLogs(res.data);
+        const response = await axios.get<Site[]>(`${API_URL}/sites`);
+        if (!isMounted) return;
+        setSites(response.data);
+        if (response.data.length > 0) {
+          setSelectedSiteUrl((current) => current || response.data[0].url);
+        }
       } catch (err) {
-        console.error("Ошибка загрузки логов:", err);
+        console.error("Failed to load sites", err);
+        if (isMounted) {
+          setOverviewError("Не удалось загрузить список сайтов");
+        }
       }
     };
 
-    fetchLogs(selectedSite); // ✅ первый запрос сразу
-    const interval = setInterval(() => fetchLogs(selectedSite), 1000);
+    loadSites();
+    return () => {
+      isMounted = false;
+    };
+  }, []);
 
-    return () => clearInterval(interval);
-  }, [selectedSite]);
+  const fetchOverviewData = useCallback(
+    async (signal?: AbortSignal) => {
+      setIsOverviewLoading(true);
+      const since = new Date(Date.now() - timeRangeConfig.durationMs).toISOString();
+      try {
+        const response = await axios.get<AggregatedDashboardResponse>(`${API_URL}/logs/aggregated`, {
+          params: {
+            since,
+            group_by: timeRangeConfig.groupBy,
+          },
+          signal,
+        });
+        if (signal?.aborted) return;
+        setOverview(response.data);
+        setOverviewError(null);
+      } catch (err) {
+        if (err instanceof CanceledError || signal?.aborted) {
+          return;
+        }
+        console.error("Failed to load overview", err);
+        setOverviewError("Не удалось загрузить общую статистику");
+      } finally {
+        if (!signal?.aborted) {
+          setIsOverviewLoading(false);
+        }
+      }
+    },
+    [timeRangeConfig.durationMs, timeRangeConfig.groupBy],
+  );
 
+  const fetchSiteData = useCallback(
+    async (signal?: AbortSignal) => {
+      if (!selectedSiteUrl) {
+        setLogs([]);
+        setSiteAggregate(null);
+        return;
+      }
+
+      setIsSiteLoading(true);
+      const since = new Date(Date.now() - timeRangeConfig.durationMs).toISOString();
+
+      try {
+        const [aggregateResponse, logsResponse] = await Promise.all([
+          axios.get<AggregatedDashboardResponse>(`${API_URL}/logs/aggregated`, {
+            params: {
+              since,
+              group_by: timeRangeConfig.groupBy,
+              url: selectedSiteUrl,
+            },
+            signal,
+          }),
+          axios.get<LogRecord[]>(`${API_URL}/logs`, {
+            params: {
+              url: selectedSiteUrl,
+              limit,
+              since,
+            },
+            signal,
+          }),
+        ]);
+
+        if (signal?.aborted) return;
+
+        setSiteAggregate(aggregateResponse.data);
+        const payload = Array.isArray(logsResponse.data) ? logsResponse.data : [];
+        setLogs(payload);
+        setError(null);
+        setLastUpdated(new Date());
+      } catch (err) {
+        if (err instanceof CanceledError || signal?.aborted) {
+          return;
+        }
+        console.error("Failed to load site dashboard", err);
+        setError("Не удалось загрузить данные сайта");
+      } finally {
+        if (!signal?.aborted) {
+          setIsSiteLoading(false);
+        }
+      }
+    },
+    [limit, selectedSiteUrl, timeRangeConfig.durationMs, timeRangeConfig.groupBy],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchOverviewData(controller.signal);
+    return () => controller.abort();
+  }, [fetchOverviewData]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchSiteData(controller.signal);
+    return () => controller.abort();
+  }, [fetchSiteData]);
+
+  useEffect(() => {
+    if (!autoRefreshEnabled) return;
+    const intervalId = window.setInterval(() => {
+      fetchOverviewData();
+      fetchSiteData();
+    }, clamp(autoRefreshInterval, 1, 60) * 1000);
+    return () => window.clearInterval(intervalId);
+  }, [autoRefreshEnabled, autoRefreshInterval, fetchOverviewData, fetchSiteData]);
+
+  const handleManualRefresh = useCallback(() => {
+    fetchOverviewData();
+    fetchSiteData();
+  }, [fetchOverviewData, fetchSiteData]);
+
+  const sortedLogs = useMemo(
+    () => [...logs].sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()),
+    [logs],
+  );
+
+  const filters: LogsTableFilters = useMemo(
+    () => ({
+      traffic: trafficFilter,
+      statusRange: httpStatusRange,
+      search: searchTerm,
+      limit,
+    }),
+    [trafficFilter, httpStatusRange, searchTerm, limit],
+  );
+
+  const filteredLogs = useMemo(() => {
+    return sortedLogs.filter((log) => {
+      const trafficAllowed = filters.traffic.size === 0 || filters.traffic.has(log.traffic_light as TrafficLight);
+      if (!trafficAllowed) return false;
+
+      const status = log.http_status;
+      const statusAllowed =
+        status === null || (status >= filters.statusRange.min && status <= filters.statusRange.max);
+      if (!statusAllowed) return false;
+
+      if (filters.search.trim().length > 0) {
+        const value = log.url ?? "";
+        if (!value.toLowerCase().includes(filters.search.toLowerCase())) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+  }, [filters, sortedLogs]);
+
+  const selectedSite = useMemo(
+    () => sites.find((site) => site.url === selectedSiteUrl) ?? null,
+    [sites, selectedSiteUrl],
+  );
+
+  const overviewBuckets = useMemo(() => overview?.buckets ?? [], [overview]);
+  const overviewSummary = overview?.summary ?? summarizeAggregatedBuckets(overviewBuckets);
+  const overviewTraffic = overview?.summary?.traffic_light ?? mergeTrafficLightAggregates(overviewBuckets);
+
+  const overviewLatencySeries = useMemo(
+    () => buildAggregatedTimeseries(overviewBuckets, "latency_avg"),
+    [overviewBuckets],
+  );
+  const overviewPingSeries = useMemo(
+    () => buildAggregatedTimeseries(overviewBuckets, "ping_avg"),
+    [overviewBuckets],
+  );
+  const overviewDnsSeries = useMemo(
+    () => buildAggregatedTimeseries(overviewBuckets, "dns_success_rate"),
+    [overviewBuckets],
+  );
+  const overviewSslSeries = useMemo(
+    () => buildAggregatedTimeseries(overviewBuckets, "ssl_days_left_avg"),
+    [overviewBuckets],
+  );
+  const overviewTrafficSeries = useMemo(
+    () => buildTrafficLightTimeseries(overviewBuckets),
+    [overviewBuckets],
+  );
+
+  const overviewUptime = useMemo(() => {
+    const total = overviewTraffic.green + overviewTraffic.orange + overviewTraffic.red;
+    if (total === 0) return null;
+    return Number(((overviewTraffic.green / total) * 100).toFixed(1));
+  }, [overviewTraffic]);
+
+  const overviewUptimeTrend = useMemo(() => {
+    return overviewBuckets
+      .map((bucket) => {
+        const total =
+          bucket.traffic_light.green + bucket.traffic_light.orange + bucket.traffic_light.red;
+        if (total === 0) return null;
+        return {
+          timestamp: new Date(bucket.timestamp).getTime(),
+          value: Number(((bucket.traffic_light.green / total) * 100).toFixed(1)),
+        };
+      })
+      .filter((value): value is { timestamp: number; value: number } => value !== null);
+  }, [overviewBuckets]);
+
+  const overviewLatencyTrend = useMemo(() => buildTrend(overviewLatencySeries), [overviewLatencySeries]);
+  const overviewPingTrend = useMemo(() => buildTrend(overviewPingSeries), [overviewPingSeries]);
+  const overviewDnsTrend = useMemo(() => buildTrend(overviewDnsSeries), [overviewDnsSeries]);
+  const overviewSslTrend = useMemo(() => buildTrend(overviewSslSeries), [overviewSslSeries]);
+
+  const siteBuckets = useMemo(() => siteAggregate?.buckets ?? [], [siteAggregate]);
+  const siteSummary = siteAggregate?.summary ?? summarizeAggregatedBuckets(siteBuckets);
+  const siteTrafficRaw = siteAggregate?.summary?.traffic_light ?? mergeTrafficLightAggregates(siteBuckets);
+  const siteTrafficFallback = useMemo(() => aggregateTrafficLight(sortedLogs), [sortedLogs]);
+  const siteTraffic = useMemo(() => {
+    const total = siteTrafficRaw.green + siteTrafficRaw.orange + siteTrafficRaw.red;
+    if (total === 0 && sortedLogs.length > 0) {
+      return siteTrafficFallback;
+    }
+    return siteTrafficRaw;
+  }, [siteTrafficFallback, siteTrafficRaw, sortedLogs.length]);
+
+  const siteLatencySeries = useMemo(
+    () => buildAggregatedTimeseries(siteBuckets, "latency_avg"),
+    [siteBuckets],
+  );
+  const sitePingSeries = useMemo(
+    () => buildAggregatedTimeseries(siteBuckets, "ping_avg"),
+    [siteBuckets],
+  );
+  const siteDnsSeries = useMemo(
+    () => buildAggregatedTimeseries(siteBuckets, "dns_success_rate"),
+    [siteBuckets],
+  );
+  const siteSslSeries = useMemo(
+    () => buildAggregatedTimeseries(siteBuckets, "ssl_days_left_avg"),
+    [siteBuckets],
+  );
+
+  const siteLatencyTrend = useMemo(() => buildTrend(siteLatencySeries), [siteLatencySeries]);
+  const sitePingTrend = useMemo(() => buildTrend(sitePingSeries), [sitePingSeries]);
+  const siteDnsTrend = useMemo(() => buildTrend(siteDnsSeries), [siteDnsSeries]);
+  const siteSslTrend = useMemo(() => buildTrend(siteSslSeries), [siteSslSeries]);
+
+  const siteLatencyAvg = siteSummary.latency_avg;
+  const sitePingAvg = siteSummary.ping_avg;
+  const siteDnsSuccess = siteSummary.dns_success_rate ?? calcDnsSuccessRate(sortedLogs);
+  const siteSslAvg = siteSummary.ssl_days_left_avg;
+  const siteChecks = sortedLogs.length;
+  const uptime = useMemo(() => calcUptime(sortedLogs), [sortedLogs]);
+  const sslDaysLeftMin = useMemo(() => minSslDays(sortedLogs), [sortedLogs]);
+  const incidentsCount = useMemo(() => countIncidents(filteredLogs), [filteredLogs]);
+
+  const latencyDrawerTrend = useMemo(() => {
+    if (!selectedLog) return [];
+    const index = sortedLogs.findIndex((log) => log.timestamp === selectedLog.timestamp);
+    const slice = index === -1 ? sortedLogs.slice(-10) : sortedLogs.slice(Math.max(0, index - 9), index + 1);
+    return getSparklineSeries(slice, "latency_ms");
+  }, [selectedLog, sortedLogs]);
+
+  const pingDrawerTrend = useMemo(() => {
+    if (!selectedLog) return [];
+    const index = sortedLogs.findIndex((log) => log.timestamp === selectedLog.timestamp);
+    const slice = index === -1 ? sortedLogs.slice(-10) : sortedLogs.slice(Math.max(0, index - 9), index + 1);
+    return getSparklineSeries(slice, "ping_ms");
+  }, [selectedLog, sortedLogs]);
+
+  const latestLog = filteredLogs[filteredLogs.length - 1] ?? sortedLogs[sortedLogs.length - 1] ?? null;
+  const activeTrafficLight = latestLog?.traffic_light ?? "green";
+
+  const statusBadgeClass = useMemo(() => {
+    switch (activeTrafficLight) {
+      case "red":
+        return "bg-rose-100 text-rose-700 border border-rose-200";
+      case "orange":
+        return "bg-amber-100 text-amber-700 border border-amber-200";
+      default:
+        return "bg-emerald-100 text-emerald-700 border border-emerald-200";
+    }
+  }, [activeTrafficLight]);
+  const handleToggleTraffic = useCallback((traffic: TrafficLight) => {
+    setTrafficFilter((prev) => {
+      const next = new Set(prev);
+      if (next.has(traffic)) {
+        next.delete(traffic);
+        if (next.size === 0) {
+          return new Set(TRAFFIC_OPTIONS);
+        }
+      } else {
+        next.add(traffic);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleStatusRangeChange = useCallback((range: { min: number; max: number }) => {
+    setHttpStatusRange({
+      min: clamp(range.min, 100, 599),
+      max: clamp(range.max, 100, 599),
+    });
+  }, []);
+
+  const overviewSiteCount = sites.length;
+  const sslAccent =
+    sslDaysLeftMin === null ? "default" : sslDaysLeftMin <= 0 ? "danger" : sslDaysLeftMin < 7 ? "warning" : "default";
 
   return (
-    <div className="p-6 space-y-6">
-      <h1 className="text-2xl font-bold tracking-tight">📊 Dashboard</h1>
-
-      <Tabs
-        value={selectedSite}
-        onValueChange={(val) => setSelectedSite(val)}
-        className="w-full"
-      >
-        <TabsList className="flex flex-wrap gap-2">
-          {sites.map((s) => (
-            <TabsTrigger key={s.url} value={s.url}>
-              {s.name}
-            </TabsTrigger>
-          ))}
-        </TabsList>
-
-        {sites.map((s) => (
-          <TabsContent key={s.url} value={s.url} className="space-y-6">
-            <Card>
-              <CardHeader>
-                <CardTitle>
-                  {s.name} ({s.url})
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                {logs.length > 0 ? (
-                  <div className="flex items-center gap-4">
-                    <span
-                      className={`text-lg font-bold`}
-                      style={{
-                        color: COLORS[logs[0].traffic_light] || "#000",
-                      }}
-                    >
-                      ● {logs[0].traffic_light.toUpperCase()}
-                    </span>
-                    <span>Последний HTTP: {logs[0].http_status}</span>
-                    <span>SSL: {logs[0].ssl_days_left ?? "—"} дней</span>
+    <div className="flex h-full flex-1 flex-col overflow-hidden bg-slate-100/60">
+      <div className="flex-1 overflow-y-auto">
+        <div className="mx-auto flex max-w-[1600px] flex-col gap-12 px-6 pb-16 pt-6">
+          <div className="sticky top-16 z-40 -mx-6">
+            <div className="rounded-3xl border border-slate-200/80 bg-white/95 px-6 py-6 shadow-[0_20px_60px_-32px_rgba(15,23,42,0.45)] backdrop-blur">
+              <div className="space-y-6">
+                <div className="flex flex-wrap items-start justify-between gap-4">
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+                      <span>Дашборд</span>
+                      <span className="h-1 w-1 rounded-full bg-slate-300" />
+                      <span>Общая статистика</span>
+                    </div>
+                    <h1 className="text-2xl font-semibold text-slate-900">Мониторинг доступности</h1>
+                    <p className="text-sm text-slate-500">Все сайты за выбранный период.</p>
                   </div>
-                ) : (
-                  <p>Нет данных</p>
-                )}
-              </CardContent>
-            </Card>
-
-            {/* Latency график */}
-            <Card>
-              <CardHeader>
-                <CardTitle>HTTP Latency (ms)</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <ResponsiveContainer width="100%" height={300}>
-                  <LineChart data={logs}>
-                    <XAxis dataKey="timestamp" hide />
-                    <YAxis />
-                    <Tooltip />
-                    <Legend />
-                    <Line
-                      type="monotone"
-                      dataKey="latency_ms"
-                      stroke="#3b82f6"
-                      name="Latency"
-                      dot={false}
+                  <div className="flex flex-col items-end gap-2">
+                    <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/90 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                      <span className="h-2 w-2 rounded-full bg-slate-400" />
+                      {`Сайтов: ${overviewSiteCount}`}
+                    </span>
+                    {overviewError ? <span className="text-sm text-rose-600">{overviewError}</span> : null}
+                  </div>
+                </div>
+                <div className="grid gap-4 xl:grid-cols-7">
+                  <div className="grid gap-4 sm:grid-cols-2 xl:col-span-5 xl:grid-cols-5">
+                    <MetricCard
+                      title="Доступность"
+                      value={formatPercent(overviewUptime)}
+                      trend={overviewUptimeTrend}
+                      trendFormatter={(value) => `${value.toFixed(1)}%`}
                     />
-                  </LineChart>
-                </ResponsiveContainer>
-              </CardContent>
-            </Card>
-
-            {/* Ping график */}
-            <Card>
-              <CardHeader>
-                <CardTitle>Ping (ms)</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <ResponsiveContainer width="100%" height={300}>
-                  <LineChart data={logs}>
-                    <XAxis dataKey="timestamp" hide />
-                    <YAxis />
-                    <Tooltip />
-                    <Legend />
-                    <Line
-                      type="monotone"
-                      dataKey="ping_ms"
-                      stroke="#10b981"
-                      name="Ping"
-                      dot={false}
+                    <MetricCard
+                      title="Средняя латентность"
+                      value={formatMs(overviewSummary.latency_avg)}
+                      trend={overviewLatencyTrend}
                     />
-                  </LineChart>
-                </ResponsiveContainer>
-              </CardContent>
-            </Card>
-
-            {/* Диаграмма распределения светофора */}
-            <Card>
-              <CardHeader>
-                <CardTitle>Traffic Light Distribution</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <ResponsiveContainer width="100%" height={300}>
-                  <PieChart>
-                    <Pie
-                      data={Object.entries(
-                        logs.reduce((acc, l) => {
-                          acc[l.traffic_light] =
-                            (acc[l.traffic_light] || 0) + 1;
-                          return acc;
-                        }, {} as Record<string, number>)
-                      ).map(([key, value]) => ({ name: key, value }))}
-                      dataKey="value"
-                      nameKey="name"
-                      outerRadius={100}
-                      label
-                    >
-                      {Object.keys(COLORS).map((key) => (
-                        <Cell key={key} fill={COLORS[key]} />
-                      ))}
-                    </Pie>
-                    <Tooltip />
-                  </PieChart>
-                </ResponsiveContainer>
-              </CardContent>
-            </Card>
-          </TabsContent>
-        ))}
-      </Tabs>
+                    <MetricCard
+                      title="Средний пинг"
+                      value={formatMs(overviewSummary.ping_avg)}
+                      trend={overviewPingTrend}
+                    />
+                    <MetricCard
+                      title="% успешных DNS"
+                      value={formatPercent(overviewSummary.dns_success_rate)}
+                      trend={overviewDnsTrend}
+                      trendFormatter={(value) => `${value.toFixed(1)}%`}
+                    />
+                    <MetricCard
+                      title="Средний срок SSL"
+                      value={formatDays(overviewSummary.ssl_days_left_avg)}
+                      trend={overviewSslTrend}
+                      trendFormatter={(value) => `${value.toFixed(1)} дн.`}
+                    />
+                  </div>
+                  <div className="xl:col-span-2">
+                    <TrafficLightPie data={overviewTraffic} title="Светофор (все сайты)" />
+                  </div>
+                </div>
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+                  <div className="flex-1 overflow-x-auto">
+                    <div className="flex w-max gap-2">
+                      {sites.length > 0 ? (
+                        sites.map((site) => {
+                          const isActive = site.url === selectedSiteUrl;
+                          return (
+                            <button
+                              key={site.url}
+                              type="button"
+                              aria-pressed={isActive}
+                              onClick={() => setSelectedSiteUrl(site.url)}
+                              className={`group flex min-w-[200px] items-center gap-3 rounded-2xl border px-4 py-3 text-left shadow-sm transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 ${
+                                isActive
+                                  ? "border-slate-900 bg-slate-900 text-white shadow-lg"
+                                  : "border-slate-200 bg-white/70 text-slate-600 hover:border-slate-300 hover:bg-white"
+                              }`}
+                            >
+                              <span
+                                className={`flex h-8 w-8 items-center justify-center rounded-full text-sm font-semibold ${
+                                  isActive ? "bg-white/20 text-white" : "bg-slate-900/10 text-slate-700"
+                                }`}
+                              >
+                                {getInitials(site)}
+                              </span>
+                              <div className="flex flex-col">
+                                <span className="text-sm font-semibold leading-5">{getHostname(site)}</span>
+                                <span className={`text-xs ${isActive ? "text-white/80" : "text-slate-400"}`}>{site.url}</span>
+                              </div>
+                            </button>
+                          );
+                        })
+                      ) : (
+                        <span className="text-sm text-slate-400">Нет доступных сайтов</span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex flex-col gap-3 text-sm text-slate-600">
+                    <div className="flex flex-wrap items-center justify-end gap-2">
+                      <div className="flex items-center gap-1 rounded-full bg-slate-100 p-1">
+                        {TIME_RANGES.map((option) => {
+                          const isActive = option.value === timeRange;
+                          return (
+                            <button
+                              key={option.value}
+                              type="button"
+                              onClick={() => setTimeRange(option.value)}
+                              className={`rounded-full px-3 py-1.5 text-sm font-medium transition ${
+                                isActive ? "bg-white text-slate-900 shadow" : "text-slate-500 hover:text-slate-700"
+                              }`}
+                            >
+                              {option.label}
+                            </button>
+                          );
+                        })}
+                      </div>
+                      <label className="flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm shadow-sm">
+                        <input
+                          type="checkbox"
+                          className="h-4 w-4 accent-slate-900"
+                          checked={autoRefreshEnabled}
+                          onChange={(event) => setAutoRefreshEnabled(event.target.checked)}
+                        />
+                        Авто
+                      </label>
+                      <div className="flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm shadow-sm">
+                        <span>интервал</span>
+                        <input
+                          type="number"
+                          min={1}
+                          max={60}
+                          step={1}
+                          value={autoRefreshInterval}
+                          onChange={(event) => setAutoRefreshInterval(clamp(Number(event.target.value) || 1, 1, 60))}
+                          className="h-7 w-16 rounded-full border border-slate-200 bg-white px-2 text-right text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400"
+                          aria-label="Интервал автообновления, секунд"
+                        />
+                        <span>сек</span>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={handleManualRefresh}
+                        className="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400"
+                      >
+                        <RefreshCw className={`h-4 w-4 ${isSiteLoading || isOverviewLoading ? "animate-spin" : ""}`} />
+                        Обновить
+                      </button>
+                    </div>
+                    <div className="flex flex-wrap justify-end gap-x-4 gap-y-1 text-xs text-slate-400">
+                      {lastUpdated ? <span>Обновлено {lastUpdated.toLocaleTimeString()}</span> : null}
+                      {isSiteLoading || isOverviewLoading ? <span>Обновляем данные…</span> : null}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <section className="space-y-6">
+            <div className="grid gap-4 xl:grid-cols-2">
+              <LatencyChart
+                data={overviewLatencySeries}
+                label="Латентность (все сайты)"
+                tooltipFormatter={aggregatedTooltip("Латентность", "мс")}
+              />
+              <PingChart
+                data={overviewPingSeries}
+                label="Пинг (все сайты)"
+                tooltipFormatter={aggregatedTooltip("Пинг", "мс")}
+              />
+            </div>
+            <TrafficLightTimeline data={overviewTrafficSeries} title="Распределение статусов (все сайты)" />
+          </section>
+          <section className="space-y-6">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div className="space-y-1">
+                <span className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Выбранный сайт</span>
+                <h2 className="text-xl font-semibold text-slate-900">
+                  {selectedSite ? getHostname(selectedSite) : "Выберите ресурс"}
+                </h2>
+                <p className="text-sm text-slate-500">
+                  {selectedSite ? selectedSite.url : "Выберите сайт из панели выше, чтобы увидеть детали."}
+                </p>
+              </div>
+              {selectedSite ? (
+                <span className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium capitalize ${statusBadgeClass}`}>
+                  <span className="h-2 w-2 rounded-full bg-current" />
+                  {activeTrafficLight}
+                </span>
+              ) : null}
+            </div>
+            {error ? (
+              <div className="rounded-2xl border border-rose-200/80 bg-rose-50/80 px-4 py-3 text-sm text-rose-700 shadow-sm">{error}</div>
+            ) : null}
+            <div className="grid gap-4 xl:grid-cols-5">
+              <div className="grid gap-4 sm:grid-cols-2 xl:col-span-4 xl:grid-cols-4">
+                <MetricCard
+                  title="Средняя латентность"
+                  value={formatMs(siteLatencyAvg)}
+                  trend={siteLatencyTrend}
+                />
+                <MetricCard
+                  title="Средний пинг"
+                  value={formatMs(sitePingAvg)}
+                  trend={sitePingTrend}
+                />
+                <MetricCard title="Доступность" value={uptime === null ? "—" : `${uptime}%`} />
+                <MetricCard
+                  title="% успешных DNS"
+                  value={formatPercent(siteDnsSuccess)}
+                  trend={siteDnsTrend}
+                  trendFormatter={(value) => `${value.toFixed(1)}%`}
+                />
+                <MetricCard
+                  title="Средний срок SSL"
+                  value={formatDays(siteSslAvg)}
+                  trend={siteSslTrend}
+                  trendFormatter={(value) => `${value.toFixed(1)} дн.`}
+                  accent={sslAccent}
+                />
+              </div>
+              <MetricCard title="Проверок" value={siteChecks} description="Количество записей в выборке" compact />
+            </div>
+            <IncidentBanner incidentCount={incidentsCount} windowSize={filteredLogs.length || siteChecks} />
+            <div className="grid gap-4 xl:grid-cols-2">
+              <LatencyChart
+                data={siteLatencySeries}
+                label="Латентность сайта"
+                tooltipFormatter={aggregatedTooltip("Латентность", "мс")}
+              />
+              <PingChart
+                data={sitePingSeries}
+                label="Пинг сайта"
+                tooltipFormatter={aggregatedTooltip("Пинг", "мс")}
+              />
+            </div>
+            <div className="grid gap-4 xl:grid-cols-4">
+              <div className="xl:col-span-2">
+                <TimeseriesChart
+                  data={siteSslSeries}
+                  color="#0ea5e9"
+                  label="SSL, дни"
+                  valueFormatter={(value) => `${value.toFixed(1)} дн.`}
+                  tooltipFormatter={aggregatedTooltip("SSL", "дн.", 1)}
+                />
+              </div>
+              <TimeseriesChart
+                data={siteDnsSeries}
+                color="#22c55e"
+                label="DNS, %"
+                valueFormatter={(value) => `${value.toFixed(1)}%`}
+                tooltipFormatter={aggregatedTooltip("DNS", "%", 1)}
+              />
+              <TrafficLightPie data={siteTraffic} title="Светофор сайта" />
+            </div>
+            <LogsTable
+              logs={filteredLogs}
+              onRowClick={setSelectedLog}
+              filters={filters}
+              onToggleTraffic={handleToggleTraffic}
+              onStatusChange={handleStatusRangeChange}
+              onSearchChange={setSearchTerm}
+              onLimitChange={setLimit}
+            />
+          </section>
+        </div>
+      </div>
+      <LogDetailsDrawer
+        log={selectedLog}
+        open={Boolean(selectedLog)}
+        onClose={() => setSelectedLog(null)}
+        latencyTrend={latencyDrawerTrend}
+        pingTrend={pingDrawerTrend}
+      />
     </div>
   );
+
 }
+

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -1,0 +1,271 @@
+export type TrafficLight = "green" | "orange" | "red";
+
+export type LogRecord = {
+  timestamp: string;
+  traffic_light: TrafficLight;
+  http_status: number | null;
+  latency_ms: number | null;
+  ping_ms: number | null;
+  ssl_days_left: number | null;
+  dns_resolved: number | boolean | null;
+  redirects: number | null;
+  url?: string | null;
+};
+
+export type TrafficLightAggregate = {
+  green: number;
+  orange: number;
+  red: number;
+};
+
+export type AggregatedBucket = {
+  timestamp: string;
+  count: number;
+  latency_avg: number | null;
+  ping_avg: number | null;
+  ssl_days_left_avg: number | null;
+  dns_success_rate: number | null;
+  traffic_light: TrafficLightAggregate;
+};
+
+export type AggregatedSummary = {
+  latency_avg: number | null;
+  ping_avg: number | null;
+  ssl_days_left_avg: number | null;
+  dns_success_rate: number | null;
+  traffic_light: TrafficLightAggregate;
+};
+
+export type AggregatedDashboardResponse = {
+  summary: AggregatedSummary;
+  buckets: AggregatedBucket[];
+};
+
+const asNumber = (value: number | null | undefined) =>
+  typeof value === "number" && Number.isFinite(value) ? value : null;
+
+const toFixedNumber = (value: number, digits = 2) => Number(value.toFixed(digits));
+
+export function calcAvgLatency(logs: LogRecord[]): number | null {
+  const values = logs
+    .map((log) => asNumber(log.latency_ms))
+    .filter((value): value is number => value !== null);
+
+  if (values.length === 0) return null;
+
+  const sum = values.reduce((acc, value) => acc + value, 0);
+  return Math.round(sum / values.length);
+}
+
+export function calcAvgPing(logs: LogRecord[]): number | null {
+  const values = logs
+    .map((log) => asNumber(log.ping_ms))
+    .filter((value): value is number => value !== null);
+
+  if (values.length === 0) return null;
+
+  const sum = values.reduce((acc, value) => acc + value, 0);
+  return Math.round(sum / values.length);
+}
+
+export function calcUptime(logs: LogRecord[]): number | null {
+  if (logs.length === 0) return null;
+
+  const successful = logs.filter((log) => {
+    if (log.http_status === null || log.http_status === undefined) return false;
+    return log.http_status < 400;
+  }).length;
+
+  return Math.round((successful / logs.length) * 100);
+}
+
+export function minSslDays(logs: LogRecord[]): number | null {
+  const values = logs
+    .map((log) => asNumber(log.ssl_days_left))
+    .filter((value): value is number => value !== null);
+
+  if (values.length === 0) return null;
+
+  return Math.min(...values);
+}
+
+export function calcDnsSuccessRate(logs: LogRecord[]): number | null {
+  if (logs.length === 0) return null;
+
+  const success = logs.filter((log) => {
+    if (log.dns_resolved === null || log.dns_resolved === undefined) return false;
+    if (typeof log.dns_resolved === "boolean") return log.dns_resolved;
+    return Number(log.dns_resolved) === 1;
+  }).length;
+
+  return toFixedNumber((success / logs.length) * 100, 1);
+}
+
+export function aggregateTrafficLight(logs: LogRecord[]): TrafficLightAggregate {
+  return logs.reduce<TrafficLightAggregate>(
+    (acc, log) => {
+      acc[log.traffic_light] += 1;
+      return acc;
+    },
+    { green: 0, orange: 0, red: 0 },
+  );
+}
+
+export function mergeTrafficLightAggregates(buckets: AggregatedBucket[]): TrafficLightAggregate {
+  return buckets.reduce<TrafficLightAggregate>(
+    (acc, bucket) => {
+      acc.green += bucket.traffic_light.green;
+      acc.orange += bucket.traffic_light.orange;
+      acc.red += bucket.traffic_light.red;
+      return acc;
+    },
+    { green: 0, orange: 0, red: 0 },
+  );
+}
+
+export function countIncidents(logs: LogRecord[]): number {
+  return logs.filter((log) => log.traffic_light === "orange" || log.traffic_light === "red").length;
+}
+
+export function getSparklineSeries(
+  logs: LogRecord[],
+  field: "latency_ms" | "ping_ms",
+): { timestamp: number; value: number }[] {
+  return logs
+    .map((log) => {
+      const value = asNumber(log[field]);
+      if (value === null) return null;
+      return {
+        timestamp: new Date(log.timestamp).getTime(),
+        value,
+      };
+    })
+    .filter((value): value is { timestamp: number; value: number } => value !== null);
+}
+
+export type ChartPoint<TMeta = unknown> = {
+  timestamp: number;
+  value: number;
+  meta?: TMeta;
+};
+
+export function buildTimeseries(
+  logs: LogRecord[],
+  field: "latency_ms" | "ping_ms",
+  maxPoints = 3000,
+): ChartPoint<LogRecord>[] {
+  const points: ChartPoint<LogRecord>[] = [];
+
+  const safeLogs = logs.filter((log) => asNumber(log[field]) !== null);
+  if (safeLogs.length === 0) return points;
+
+  const bucketSize = Math.max(1, Math.ceil(safeLogs.length / maxPoints));
+
+  for (let i = 0; i < safeLogs.length; i += bucketSize) {
+    const bucket = safeLogs.slice(i, i + bucketSize);
+    const avgValue =
+      bucket.reduce((sum, log) => sum + (asNumber(log[field]) ?? 0), 0) /
+      bucket.length;
+    const referenceLog = bucket[bucket.length - 1];
+    points.push({
+      timestamp: new Date(referenceLog.timestamp).getTime(),
+      value: toFixedNumber(avgValue),
+      meta: referenceLog,
+    });
+  }
+
+  return points;
+}
+
+type AggregatedField = keyof Pick<
+  AggregatedBucket,
+  "latency_avg" | "ping_avg" | "ssl_days_left_avg" | "dns_success_rate"
+>;
+
+export function buildAggregatedTimeseries(
+  buckets: AggregatedBucket[],
+  field: AggregatedField,
+): ChartPoint<AggregatedBucket>[] {
+  return buckets
+    .map((bucket) => {
+      const rawValue = bucket[field];
+      if (typeof rawValue !== "number" || !Number.isFinite(rawValue)) return null;
+      return {
+        timestamp: new Date(bucket.timestamp).getTime(),
+        value: toFixedNumber(rawValue),
+        meta: bucket,
+      } satisfies ChartPoint<AggregatedBucket>;
+    })
+    .filter((value): value is ChartPoint<AggregatedBucket> => value !== null);
+}
+
+export type TrafficLightTimeseriesPoint = {
+  timestamp: number;
+  green: number;
+  orange: number;
+  red: number;
+  total: number;
+};
+
+export function buildTrafficLightTimeseries(buckets: AggregatedBucket[]): TrafficLightTimeseriesPoint[] {
+  return buckets.map((bucket) => {
+    const green = bucket.traffic_light.green ?? 0;
+    const orange = bucket.traffic_light.orange ?? 0;
+    const red = bucket.traffic_light.red ?? 0;
+    const total = green + orange + red;
+    return {
+      timestamp: new Date(bucket.timestamp).getTime(),
+      green,
+      orange,
+      red,
+      total,
+    } satisfies TrafficLightTimeseriesPoint;
+  });
+}
+
+export function summarizeAggregatedBuckets(
+  buckets: AggregatedBucket[],
+): AggregatedSummary {
+  if (buckets.length === 0) {
+    return {
+      latency_avg: null,
+      ping_avg: null,
+      ssl_days_left_avg: null,
+      dns_success_rate: null,
+      traffic_light: { green: 0, orange: 0, red: 0 },
+    } satisfies AggregatedSummary;
+  }
+
+  const totals = buckets.reduce(
+    (acc, bucket) => {
+      const count = bucket.count || 0;
+      acc.count += count;
+      acc.latency += (bucket.latency_avg ?? 0) * count;
+      acc.ping += (bucket.ping_avg ?? 0) * count;
+      acc.ssl += (bucket.ssl_days_left_avg ?? 0) * count;
+      acc.dns += (bucket.dns_success_rate ?? 0) * count;
+      acc.traffic.green += bucket.traffic_light.green;
+      acc.traffic.orange += bucket.traffic_light.orange;
+      acc.traffic.red += bucket.traffic_light.red;
+      return acc;
+    },
+    {
+      count: 0,
+      latency: 0,
+      ping: 0,
+      ssl: 0,
+      dns: 0,
+      traffic: { green: 0, orange: 0, red: 0 },
+    },
+  );
+
+  const safeCount = Math.max(1, totals.count);
+
+  return {
+    latency_avg: totals.count === 0 ? null : toFixedNumber(totals.latency / safeCount),
+    ping_avg: totals.count === 0 ? null : toFixedNumber(totals.ping / safeCount),
+    ssl_days_left_avg: totals.count === 0 ? null : toFixedNumber(totals.ssl / safeCount),
+    dns_success_rate: totals.count === 0 ? null : toFixedNumber(totals.dns / safeCount),
+    traffic_light: totals.traffic,
+  } satisfies AggregatedSummary;
+}


### PR DESCRIPTION
## Summary
- localize the time range selector and compute aggregated uptime to surface in the global stats block
- rebuild the dashboard return layout with a sticky global summary, modern site selector, and reorganized site analytics sections

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce7fd60890832b94f44cc219f7cd39