### PR TITLE
feat: improve website node editing experience

### DIFF
--- a/src/components/Inspector.tsx
+++ b/src/components/Inspector.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useMemo, useState, type ChangeEventHandler } from "react";
+import { useEffect, useMemo, useRef, useState, type ChangeEventHandler } from "react";
 import clsx from "clsx";
 import { useShallow } from "zustand/react/shallow";
 
 import { useFlowStore } from "../state/store";
-import type { BlockVariant, NodeStatus } from "../flow/nodes/types";
+import { DEFAULT_PING_INTERVAL, type BlockVariant, type NodeStatus } from "../flow/nodes/types";
 
 const statusOptions: { value: NodeStatus; label: string; className: string }[] = [
   { value: "idle", label: "Ожидание", className: "border-slate-200 bg-slate-50 text-slate-500 hover:border-slate-300 hover:text-slate-600" },
@@ -19,13 +19,17 @@ const typeLabels: Record<BlockVariant, string> = {
 };
 
 export default function Inspector() {
-  const { selectedNodeId, nodes, updateNodeData } = useFlowStore(
-    useShallow((state) => ({
-      selectedNodeId: state.selectedNodeId,
-      nodes: state.nodes,
-      updateNodeData: state.updateNodeData,
-    }))
-  );
+  const { selectedNodeId, nodes, updateNodeData, deleteSiteNode, removeNode, setSelectedNode } =
+    useFlowStore(
+      useShallow((state) => ({
+        selectedNodeId: state.selectedNodeId,
+        nodes: state.nodes,
+        updateNodeData: state.updateNodeData,
+        deleteSiteNode: state.deleteSiteNode,
+        removeNode: state.removeNode,
+        setSelectedNode: state.setSelectedNode,
+      }))
+    );
 
   const node = useMemo(
     () => nodes.find((candidate) => candidate.id === selectedNodeId),
@@ -36,7 +40,10 @@ export default function Inspector() {
     title: "",
     description: "",
     status: "idle" as NodeStatus,
+    ping_interval: String(DEFAULT_PING_INTERVAL),
   });
+
+  const firstFieldRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     if (!node) return;
@@ -44,8 +51,17 @@ export default function Inspector() {
       title: node.data.title ?? "",
       description: node.data.description ?? "",
       status: node.data.status ?? "idle",
+      ping_interval: String(node.data.ping_interval ?? DEFAULT_PING_INTERVAL),
     });
   }, [node]);
+
+  useEffect(() => {
+    if (!selectedNodeId) return;
+    requestAnimationFrame(() => {
+      firstFieldRef.current?.focus();
+      firstFieldRef.current?.select();
+    });
+  }, [selectedNodeId]);
 
   const handleChange = (
     field: "title" | "description"
@@ -65,6 +81,65 @@ export default function Inspector() {
     if (node && node.data.status !== status) {
       updateNodeData(node.id, { status });
     }
+  };
+
+  const handlePingIntervalChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+    const raw = event.target.value;
+    setForm((prev) => ({ ...prev, ping_interval: raw }));
+
+    if (!node) return;
+    if (raw.trim() === "") return;
+
+    const numeric = Number(raw);
+    if (Number.isNaN(numeric)) return;
+
+    const normalized = Math.round(numeric);
+    if (normalized <= 0) return;
+
+    if (node.data.ping_interval !== normalized) {
+      updateNodeData(node.id, { ping_interval: normalized });
+    }
+  };
+
+  const handlePingIntervalBlur = () => {
+    if (!node) return;
+
+    const fallback = node.data.ping_interval ?? DEFAULT_PING_INTERVAL;
+    const raw = form.ping_interval.trim();
+
+    if (raw === "") {
+      setForm((prev) => ({ ...prev, ping_interval: String(fallback) }));
+      return;
+    }
+
+    const numeric = Number(raw);
+    if (Number.isNaN(numeric) || numeric <= 0) {
+      setForm((prev) => ({ ...prev, ping_interval: String(fallback) }));
+      return;
+    }
+
+    const clamped = Math.min(3600, Math.max(1, Math.round(numeric)));
+    if (String(clamped) !== form.ping_interval) {
+      setForm((prev) => ({ ...prev, ping_interval: String(clamped) }));
+    }
+
+    if (node.data.ping_interval !== clamped) {
+      updateNodeData(node.id, { ping_interval: clamped });
+    }
+  };
+
+  const handleDeleteWebsite = () => {
+    if (!node || node.type !== "website") return;
+
+    if (node.id.startsWith("temp-")) {
+      removeNode(node.id);
+      setSelectedNode(undefined);
+      return;
+    }
+
+    void deleteSiteNode(node.id, Number(node.id)).finally(() => {
+      setSelectedNode(undefined);
+    });
   };
 
   if (!node) {
@@ -91,26 +166,73 @@ export default function Inspector() {
       </div>
 
       <div className="mt-5 space-y-5">
-        {/* Название */}
-        <div className="space-y-2">
-          <label className="text-xs font-semibold uppercase tracking-wide text-slate-400">Название</label>
-          <input
-            value={form.title}
-            onChange={handleChange("title")}
-            className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-200"
-          />
-        </div>
+        {node.type === "website" ? (
+          <>
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-400">Название</label>
+              <input
+                ref={firstFieldRef}
+                value={form.title}
+                onChange={handleChange("title")}
+                placeholder="Например, Главная страница"
+                className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-200"
+              />
+            </div>
 
-        {/* Описание */}
-        <div className="space-y-2">
-          <label className="text-xs font-semibold uppercase tracking-wide text-slate-400">Описание</label>
-          <textarea
-            value={form.description}
-            onChange={handleChange("description")}
-            rows={3}
-            className="w-full resize-none rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-200"
-          />
-        </div>
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-400">URL</label>
+              <input
+                value={form.description}
+                onChange={handleChange("description")}
+                placeholder="https://example.com"
+                className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-200"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-400">Интервал опроса (сек)</label>
+              <input
+                type="number"
+                min={1}
+                max={3600}
+                value={form.ping_interval}
+                onChange={handlePingIntervalChange}
+                onBlur={handlePingIntervalBlur}
+                className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-200"
+              />
+            </div>
+
+            <button
+              type="button"
+              className="w-full rounded-xl bg-rose-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-rose-700 focus:outline-none focus:ring-2 focus:ring-rose-200"
+              onClick={handleDeleteWebsite}
+            >
+              🗑 Удалить блок
+            </button>
+          </>
+        ) : (
+          <>
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-400">Название</label>
+              <input
+                ref={firstFieldRef}
+                value={form.title}
+                onChange={handleChange("title")}
+                className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-200"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-400">Описание</label>
+              <textarea
+                value={form.description}
+                onChange={handleChange("description")}
+                rows={3}
+                className="w-full resize-none rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-200"
+              />
+            </div>
+          </>
+        )}
 
         {/* Статус */}
         <div className="space-y-2">
@@ -132,65 +254,6 @@ export default function Inspector() {
             ))}
           </div>
         </div>
-
-        {/* URL для website */}
-        {node.type === "website" && (
-          <>
-            {/* URL */}
-            <div className="space-y-2">
-              <label className="text-xs font-semibold uppercase text-slate-400">URL сайта</label>
-              <input
-                value={form.description}
-                onChange={handleChange("description")}
-                className="w-full rounded-xl border px-3 py-2 text-sm text-slate-700"
-              />
-            </div>
-
-            {/* Интервал */}
-            <div className="space-y-2">
-              <label className="text-xs font-semibold uppercase text-slate-400">Интервал (сек)</label>
-              <input
-                type="number"
-                min={5}
-                max={3600}
-                value={node.data.ping_interval ?? 30}
-                onChange={(e) => updateNodeData(node.id, { ping_interval: Number(e.target.value) })}
-                className="w-full rounded-xl border px-3 py-2 text-sm text-slate-700"
-              />
-            </div>
-
-            {/* Кнопки */}
-            <div className="flex gap-2 pt-4">
-              <button
-                className="flex-1 rounded-xl bg-sky-600 px-4 py-2 text-white"
-                onClick={async () => {
-                  const saved = await useFlowStore.getState().saveSite(node);
-                  if (saved && saved.id) {
-                    useFlowStore.setState({ selectedNodeId: String(saved.id) });
-                  }
-                }}
-              >
-                💾 Сохранить
-              </button>
-              <button
-                className="flex-1 rounded-xl bg-rose-600 px-4 py-2 text-white"
-                onClick={() => {
-                  if (node.id.startsWith("temp-")) {
-                    // удалить только локально
-                    useFlowStore.setState((state) => ({
-                      nodes: state.nodes.filter((n) => n.id !== node.id),
-                    }));
-                  } else {
-                    // удалить и на сервере, и локально
-                    useFlowStore.getState().deleteSiteNode(node.id, Number(node.id));
-                  }
-                }}
-              >
-                🗑 Удалить
-              </button>
-            </div>
-          </>
-        )}
 
         {/* Метаданные read-only */}
         {node.data.metadata && node.data.metadata.length > 0 && (

--- a/src/flow/library.ts
+++ b/src/flow/library.ts
@@ -1,4 +1,4 @@
-import type { BaseNodeData, BlockVariant } from "./nodes/types";
+import { DEFAULT_PING_INTERVAL, type BaseNodeData, type BlockVariant } from "./nodes/types";
 
 export type LibraryCategory = "Источники" | "Логика" | "Доставка";
 
@@ -17,11 +17,13 @@ export const NODE_LIBRARY: LibraryNodeTemplate[] = [
     data: {
       title: "Мониторинг сайта",
       emoji: "🌐",
-      description: "Проверяет доступность страницы каждые N минут",
+      description: "https://pingtower.com",
       status: "idle",
+      ping_interval: DEFAULT_PING_INTERVAL,
       metadata: [
         { label: "URL", value: "https://pingtower.com" },
-        { label: "Период", value: "60 сек" },
+        { label: "Название", value: "Мониторинг сайта" },
+        { label: "Интервал", value: `${DEFAULT_PING_INTERVAL} сек` },
       ],
     },
   },

--- a/src/flow/nodes/WebsiteNode.tsx
+++ b/src/flow/nodes/WebsiteNode.tsx
@@ -1,15 +1,11 @@
 import type { NodeProps } from "reactflow";
 import BaseBlock from "./BaseBlock";
-import type { BaseNodeData } from "./types";
+import { buildWebsiteMetadata, type BaseNodeData } from "./types";
 
 export default function WebsiteNode(props: NodeProps<BaseNodeData>) {
   const { data } = props;
 
-  // 🔹 добавляем ping_interval в metadata, если его нет
-  const metadata = [
-    ...(data.metadata ?? []),
-    { label: "PING INTERVAL", value: `${data.ping_interval ?? 30} сек` },
-  ];
+  const metadata = data.metadata ?? buildWebsiteMetadata(data);
 
   return <BaseBlock {...props} variant="website" data={{ ...data, metadata }} />;
 }

--- a/src/flow/nodes/types.ts
+++ b/src/flow/nodes/types.ts
@@ -1,5 +1,4 @@
-import type { Node, Edge } from "reactflow";
-import type { BaseNodeData } from "../flow/nodes/types";
+import type { Edge, Node } from "reactflow";
 
 // Варианты блоков
 export type BlockVariant = "website" | "llm" | "messenger";
@@ -14,14 +13,26 @@ export type NodeMetadataEntry = {
 };
 
 // Базовые данные ноды
+export const DEFAULT_PING_INTERVAL = 30;
+
 export type BaseNodeData = {
   title?: string;
   description?: string;
   emoji?: string;
   status?: NodeStatus;
   metadata?: NodeMetadataEntry[];
-  ping_interval?: number; // 🔹 новое поле
+  ping_interval?: number;
 };
+
+export function buildWebsiteMetadata(data: BaseNodeData): NodeMetadataEntry[] {
+  const interval = data.ping_interval ?? DEFAULT_PING_INTERVAL;
+
+  return [
+    { label: "URL", value: data.description ?? "—" },
+    { label: "Название", value: data.title ?? "Без имени" },
+    { label: "Интервал", value: `${interval} сек` },
+  ];
+}
 
 // FlowNode
 export type FlowNode = Node<BaseNodeData>;

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,9 +1,24 @@
 import { create } from "zustand";
 import { fetchSites, createSite, updateSite, deleteSite } from "../lib/api";
-import type { FlowNode, BaseNodeData } from "../flow/nodes/types";
+import {
+  type BaseNodeData,
+  type FlowNode,
+  buildWebsiteMetadata,
+  DEFAULT_PING_INTERVAL,
+} from "../flow/nodes/types";
 import type { Edge } from "reactflow";
 
 export type NodeStatus = "idle" | "running" | "success" | "error";
+
+const websiteSyncTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+const cancelWebsiteSyncTimer = (nodeId: string) => {
+  const timer = websiteSyncTimers.get(nodeId);
+  if (timer) {
+    clearTimeout(timer);
+    websiteSyncTimers.delete(nodeId);
+  }
+};
 
 type FlowStore = {
   flowName: string;
@@ -22,6 +37,7 @@ type FlowStore = {
   deleteSiteNode: (nodeId: string, siteId: number) => Promise<void>;
   syncWebsiteNode: (node: FlowNode) => Promise<{ id: number; url: string; name: string; ping_interval: number } | undefined>;
   updateNodeData: (id: string, data: Partial<BaseNodeData>) => void;
+  removeNode: (nodeId: string) => void;
 
   runFlow: () => void;
   stopFlow: () => void;
@@ -66,12 +82,12 @@ export const useFlowStore = create<FlowStore>((set, get) => ({
           description: site.url,
           emoji: "🌐",
           status: "idle" as NodeStatus,
-          ping_interval: site.ping_interval ?? 30,
-          metadata: [
-            { label: "URL", value: site.url },
-            { label: "Имя", value: site.name },
-            { label: "Интервал", value: site.ping_interval?.toString() ?? "30" },
-          ],
+          ping_interval: site.ping_interval ?? DEFAULT_PING_INTERVAL,
+          metadata: buildWebsiteMetadata({
+            title: site.name,
+            description: site.url,
+            ping_interval: site.ping_interval ?? DEFAULT_PING_INTERVAL,
+          }),
         },
       }));
       set({ nodes, isDirty: false });
@@ -87,7 +103,7 @@ export const useFlowStore = create<FlowStore>((set, get) => ({
     try {
       const url = node.data.description || "";
       const name = node.data.title || "Без имени";
-      const ping_interval = node.data.ping_interval ?? 30;
+      const ping_interval = node.data.ping_interval ?? DEFAULT_PING_INTERVAL;
 
       const saved = node.id.startsWith("temp-")
         ? await createSite(url, name, ping_interval)
@@ -104,6 +120,11 @@ export const useFlowStore = create<FlowStore>((set, get) => ({
                   title: saved.name,
                   description: saved.url,
                   ping_interval: saved.ping_interval,
+                  metadata: buildWebsiteMetadata({
+                    title: saved.name,
+                    description: saved.url,
+                    ping_interval: saved.ping_interval,
+                  }),
                 },
               }
             : n
@@ -123,8 +144,9 @@ export const useFlowStore = create<FlowStore>((set, get) => ({
     try {
       await deleteSite(Number(siteId));
     } catch (err) {
-      console.warn("[FlowStore] Сервер не нашёл сайт, удаляем только локально", { nodeId, siteId });
+      console.warn("[FlowStore] Сервер не нашёл сайт, удаляем только локально", { nodeId, siteId, err });
     } finally {
+      cancelWebsiteSyncTimer(nodeId);
       set((state) => ({
         nodes: state.nodes.filter((n) => n.id !== nodeId),
         isDirty: true,
@@ -140,13 +162,55 @@ export const useFlowStore = create<FlowStore>((set, get) => ({
   },
 
   // ✏️ обновить локально
-  updateNodeData: (id, data) =>
+  updateNodeData: (id, data) => {
+    let updatedNode: FlowNode | undefined;
+
     set((state) => ({
-      nodes: state.nodes.map((node) =>
-        node.id === id ? { ...node, data: { ...node.data, ...data } } : node
-      ),
+      nodes: state.nodes.map((node) => {
+        if (node.id !== id) return node;
+
+        const nextData: BaseNodeData = {
+          ...node.data,
+          ...data,
+        };
+
+        if (node.type === "website") {
+          nextData.metadata = buildWebsiteMetadata(nextData);
+        }
+
+        const nextNode = { ...node, data: nextData };
+        updatedNode = nextNode;
+        return nextNode;
+      }),
       isDirty: true,
-    })),
+    }));
+
+    const shouldSyncWebsite =
+      updatedNode?.type === "website" &&
+      ("title" in data || "description" in data || "ping_interval" in data);
+
+    if (updatedNode && shouldSyncWebsite) {
+      const existingTimer = websiteSyncTimers.get(updatedNode.id);
+      if (existingTimer) {
+        clearTimeout(existingTimer);
+      }
+
+      const timer = setTimeout(() => {
+        void get().syncWebsiteNode(updatedNode!);
+        websiteSyncTimers.delete(updatedNode!.id);
+      }, 500);
+
+      websiteSyncTimers.set(updatedNode.id, timer);
+    }
+  },
+
+  removeNode: (nodeId) => {
+    cancelWebsiteSyncTimer(nodeId);
+    set((state) => ({
+      nodes: state.nodes.filter((node) => node.id !== nodeId),
+      isDirty: true,
+    }));
+  },
 
   runFlow: () => set({ isRunning: true, lastRunAt: new Date() }),
   stopFlow: () => set({ isRunning: false }),


### PR DESCRIPTION
## Summary
- add website inspector fields for website name, URL, and polling interval while keeping only the delete action and auto-focusing new selections
- automatically rebuild website metadata, debounce syncing to the backend, and expose a helper to remove nodes safely
- reuse the default website interval across the library and node renderer so cards always show updated values

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfdfbd49c8832bbd33be19aaa392e4