### PR TITLE
feat: prompt website pinger details on add

### DIFF
--- a/src/flow/FlowCanvas.tsx
+++ b/src/flow/FlowCanvas.tsx
@@ -66,7 +66,7 @@ function CanvasInner() {
     setNodes,
     setEdges,
     setSelectedNode,
-    syncWebsiteNode,
+    createWebsiteNode,
   } = useFlowStore(
     useShallow((state) => ({
       nodes: state.nodes,
@@ -74,7 +74,7 @@ function CanvasInner() {
       setNodes: state.setNodes,
       setEdges: state.setEdges,
       setSelectedNode: state.setSelectedNode,
-      syncWebsiteNode: state.syncWebsiteNode,
+      createWebsiteNode: state.createWebsiteNode,
     }))
   );
 
@@ -141,8 +141,13 @@ function CanvasInner() {
         y: event.clientY,
       });
 
+      if (template.type === "website") {
+        void createWebsiteNode(position, template.data);
+        return;
+      }
+
       const newNode: FlowNode = {
-        id: `temp-${nanoid()}`, // 🔹 временный id (будет заменён на id из БД при saveSite)
+        id: `temp-${nanoid()}`,
         type: template.type,
         position,
         data: { ...template.data },
@@ -150,13 +155,8 @@ function CanvasInner() {
 
       setNodes((nds) => nds.concat(newNode));
       setSelectedNode(newNode.id);
-
-      // 🔹 Если узел — сайт, сразу синхронизируем с БД
-      if (newNode.type === "website") {
-        syncWebsiteNode(newNode);
-      }
     },
-    [reactFlow, setNodes, setSelectedNode, syncWebsiteNode]
+    [createWebsiteNode, reactFlow, setNodes, setSelectedNode]
   );
 
   const backgroundGap = useMemo(() => ({ x: 40, y: 40 }), []);

--- a/src/flow/library.ts
+++ b/src/flow/library.ts
@@ -1,4 +1,9 @@
-import type { BaseNodeData, BlockVariant } from "./nodes/types";
+import {
+  DEFAULT_PING_INTERVAL,
+  buildWebsiteMetadata,
+  type BaseNodeData,
+  type BlockVariant,
+} from "./nodes/types";
 
 export type LibraryCategory = "Источники" | "Логика" | "Доставка";
 
@@ -15,14 +20,16 @@ export const NODE_LIBRARY: LibraryNodeTemplate[] = [
     type: "website",
     category: "Источники",
     data: {
-      title: "Мониторинг сайта",
+      title: "Пингер сайта",
       emoji: "🌐",
-      description: "Проверяет доступность страницы каждые N минут",
+      description: "https://example.com",
       status: "idle",
-      metadata: [
-        { label: "URL", value: "https://pingtower.com" },
-        { label: "Период", value: "60 сек" },
-      ],
+      ping_interval: DEFAULT_PING_INTERVAL,
+      metadata: buildWebsiteMetadata({
+        title: "Пингер сайта",
+        description: "https://example.com",
+        ping_interval: DEFAULT_PING_INTERVAL,
+      }),
     },
   },
   {

--- a/src/flow/nodes/WebsiteNode.tsx
+++ b/src/flow/nodes/WebsiteNode.tsx
@@ -1,15 +1,112 @@
-import type { NodeProps } from "reactflow";
+import { type MouseEventHandler } from "react";
+import { NodeToolbar, type NodeProps } from "reactflow";
+import { useFlowStore } from "../../state/store";
 import BaseBlock from "./BaseBlock";
-import type { BaseNodeData } from "./types";
+import {
+  buildWebsiteMetadata,
+  DEFAULT_PING_INTERVAL,
+  MAX_PING_INTERVAL,
+  MIN_PING_INTERVAL,
+  normalizePingInterval,
+  type BaseNodeData,
+} from "./types";
 
 export default function WebsiteNode(props: NodeProps<BaseNodeData>) {
-  const { data } = props;
+  const { data, id, selected } = props;
 
-  // 🔹 добавляем ping_interval в metadata, если его нет
-  const metadata = [
-    ...(data.metadata ?? []),
-    { label: "PING INTERVAL", value: `${data.ping_interval ?? 30} сек` },
-  ];
+  const setSelectedNode = useFlowStore((state) => state.setSelectedNode);
+  const updateNodeData = useFlowStore((state) => state.updateNodeData);
+  const deleteSiteNode = useFlowStore((state) => state.deleteSiteNode);
+  const removeNode = useFlowStore((state) => state.removeNode);
 
-  return <BaseBlock {...props} variant="website" data={{ ...data, metadata }} />;
+  const metadata = data.metadata ?? buildWebsiteMetadata(data);
+
+  const handleEditClick: MouseEventHandler<HTMLButtonElement> = (event) => {
+    event.stopPropagation();
+    setSelectedNode(id);
+
+    const state = useFlowStore.getState();
+    const current = state.nodes.find((node) => node.id === id);
+    if (!current || current.type !== "website") return;
+
+    const currentUrl = current.data.description ?? "";
+    const nextUrl = window.prompt("Введите URL сайта", currentUrl);
+    if (nextUrl === null) return;
+    const trimmedUrl = nextUrl.trim();
+
+    const currentName = current.data.title ?? "";
+    const nextName = window.prompt("Введите название сайта", currentName);
+    if (nextName === null) return;
+    const trimmedName = nextName.trim();
+
+    const currentInterval = current.data.ping_interval ?? DEFAULT_PING_INTERVAL;
+    const nextIntervalRaw = window.prompt(
+      "Введите интервал опроса (сек)",
+      String(currentInterval)
+    );
+    if (nextIntervalRaw === null) return;
+
+    const normalizedInterval = normalizePingInterval(nextIntervalRaw);
+    if (!normalizedInterval) {
+      window.alert(
+        `Интервал должен быть положительным числом от ${MIN_PING_INTERVAL} до ${MAX_PING_INTERVAL}`
+      );
+      return;
+    }
+
+    const updates: Partial<BaseNodeData> = {};
+    if (trimmedUrl !== currentUrl && trimmedUrl !== "") {
+      updates.description = trimmedUrl;
+    }
+    if (trimmedName !== currentName && trimmedName !== "") {
+      updates.title = trimmedName;
+    }
+    if (normalizedInterval !== currentInterval) {
+      updates.ping_interval = normalizedInterval;
+    }
+
+    if (Object.keys(updates).length > 0) {
+      updateNodeData(id, updates);
+    }
+  };
+
+  const handleDeleteClick: MouseEventHandler<HTMLButtonElement> = (event) => {
+    event.stopPropagation();
+    setSelectedNode(undefined);
+
+    const state = useFlowStore.getState();
+    const current = state.nodes.find((node) => node.id === id);
+    if (!current || current.type !== "website") return;
+
+    if (current.id.startsWith("temp-")) {
+      removeNode(current.id);
+      return;
+    }
+
+    void deleteSiteNode(current.id, Number(current.id));
+  };
+
+  return (
+    <>
+      <NodeToolbar isVisible={selected} position="top">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-600 shadow-sm transition hover:border-sky-300 hover:text-sky-600"
+            onClick={handleEditClick}
+          >
+            ✏️ Изменить
+          </button>
+          <button
+            type="button"
+            className="rounded-full border border-rose-200 bg-white px-3 py-1 text-xs font-semibold text-rose-600 shadow-sm transition hover:border-rose-300 hover:text-rose-600"
+            onClick={handleDeleteClick}
+          >
+            🗑 Удалить
+          </button>
+        </div>
+      </NodeToolbar>
+      <BaseBlock {...props} variant="website" data={{ ...data, metadata }} />
+    </>
+  );
 }

--- a/src/flow/nodes/types.ts
+++ b/src/flow/nodes/types.ts
@@ -1,5 +1,4 @@
-import type { Node, Edge } from "reactflow";
-import type { BaseNodeData } from "../flow/nodes/types";
+import type { Edge, Node } from "reactflow";
 
 // Варианты блоков
 export type BlockVariant = "website" | "llm" | "messenger";
@@ -14,14 +13,35 @@ export type NodeMetadataEntry = {
 };
 
 // Базовые данные ноды
+export const DEFAULT_PING_INTERVAL = 30;
+export const MIN_PING_INTERVAL = 1;
+export const MAX_PING_INTERVAL = 3600;
+
 export type BaseNodeData = {
   title?: string;
   description?: string;
   emoji?: string;
   status?: NodeStatus;
   metadata?: NodeMetadataEntry[];
-  ping_interval?: number; // 🔹 новое поле
+  ping_interval?: number;
 };
+
+export function normalizePingInterval(value: string): number | undefined {
+  const numeric = Number(value.trim());
+  if (!Number.isFinite(numeric)) return undefined;
+  if (numeric <= 0) return undefined;
+  return Math.min(MAX_PING_INTERVAL, Math.max(MIN_PING_INTERVAL, Math.round(numeric)));
+}
+
+export function buildWebsiteMetadata(data: BaseNodeData): NodeMetadataEntry[] {
+  const interval = data.ping_interval ?? DEFAULT_PING_INTERVAL;
+
+  return [
+    { label: "URL", value: data.description ?? "—" },
+    { label: "Название", value: data.title ?? "Без имени" },
+    { label: "Интервал", value: `${interval} сек` },
+  ];
+}
 
 // FlowNode
 export type FlowNode = Node<BaseNodeData>;


### PR DESCRIPTION
## Summary
- prompt for URL, name, and polling interval when dropping a website node and persist the site through the API using those values
- expose edit and delete actions on the website node toolbar that reuse shared ping interval validation helpers
- refresh the website library defaults and inspector to use the shared normalization logic for the generic pinger template

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfdfbd49c8832bbd33be19aaa392e4