### PR TITLE
feat: add telegram bot node and sync website com

### DIFF
--- a/src/components/Inspector.tsx
+++ b/src/components/Inspector.tsx
@@ -1,9 +1,16 @@
-import { useEffect, useMemo, useState, type ChangeEventHandler } from "react";
+import { useEffect, useMemo, useRef, useState, type ChangeEventHandler } from "react";
 import clsx from "clsx";
 import { useShallow } from "zustand/react/shallow";
 
 import { useFlowStore } from "../state/store";
-import type { BlockVariant, NodeStatus } from "../flow/nodes/types";
+import {
+  DEFAULT_PING_INTERVAL,
+  MAX_PING_INTERVAL,
+  MIN_PING_INTERVAL,
+  normalizePingInterval,
+  type BlockVariant,
+  type NodeStatus,
+} from "../flow/nodes/types";
 
 const statusOptions: { value: NodeStatus; label: string; className: string }[] = [
   { value: "idle", label: "Ожидание", className: "border-slate-200 bg-slate-50 text-slate-500 hover:border-slate-300 hover:text-slate-600" },
@@ -16,16 +23,21 @@ const typeLabels: Record<BlockVariant, string> = {
   website: "Источник",
   llm: "Логика",
   messenger: "Доставка",
+  telegram: "Доставка",
 };
 
 export default function Inspector() {
-  const { selectedNodeId, nodes, updateNodeData } = useFlowStore(
-    useShallow((state) => ({
-      selectedNodeId: state.selectedNodeId,
-      nodes: state.nodes,
-      updateNodeData: state.updateNodeData,
-    }))
-  );
+  const { selectedNodeId, nodes, updateNodeData, deleteSiteNode, removeNode, setSelectedNode } =
+    useFlowStore(
+      useShallow((state) => ({
+        selectedNodeId: state.selectedNodeId,
+        nodes: state.nodes,
+        updateNodeData: state.updateNodeData,
+        deleteSiteNode: state.deleteSiteNode,
+        removeNode: state.removeNode,
+        setSelectedNode: state.setSelectedNode,
+      }))
+    );
 
   const node = useMemo(
     () => nodes.find((candidate) => candidate.id === selectedNodeId),
@@ -36,7 +48,10 @@ export default function Inspector() {
     title: "",
     description: "",
     status: "idle" as NodeStatus,
+    ping_interval: String(DEFAULT_PING_INTERVAL),
   });
+
+  const firstFieldRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     if (!node) return;
@@ -44,8 +59,17 @@ export default function Inspector() {
       title: node.data.title ?? "",
       description: node.data.description ?? "",
       status: node.data.status ?? "idle",
+      ping_interval: String(node.data.ping_interval ?? DEFAULT_PING_INTERVAL),
     });
   }, [node]);
+
+  useEffect(() => {
+    if (!selectedNodeId) return;
+    requestAnimationFrame(() => {
+      firstFieldRef.current?.focus();
+      firstFieldRef.current?.select();
+    });
+  }, [selectedNodeId]);
 
   const handleChange = (
     field: "title" | "description"
@@ -65,6 +89,61 @@ export default function Inspector() {
     if (node && node.data.status !== status) {
       updateNodeData(node.id, { status });
     }
+  };
+
+  const handlePingIntervalChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+    const raw = event.target.value;
+    setForm((prev) => ({ ...prev, ping_interval: raw }));
+
+    if (!node) return;
+    if (raw.trim() === "") return;
+
+    const normalized = normalizePingInterval(raw);
+    if (!normalized) return;
+
+    if (node.data.ping_interval !== normalized) {
+      updateNodeData(node.id, { ping_interval: normalized });
+    }
+  };
+
+  const handlePingIntervalBlur = () => {
+    if (!node) return;
+
+    const fallback = node.data.ping_interval ?? DEFAULT_PING_INTERVAL;
+    const raw = form.ping_interval.trim();
+
+    if (raw === "") {
+      setForm((prev) => ({ ...prev, ping_interval: String(fallback) }));
+      return;
+    }
+
+    const normalized = normalizePingInterval(raw);
+    if (!normalized) {
+      setForm((prev) => ({ ...prev, ping_interval: String(fallback) }));
+      return;
+    }
+
+    if (String(normalized) !== form.ping_interval) {
+      setForm((prev) => ({ ...prev, ping_interval: String(normalized) }));
+    }
+
+    if (node.data.ping_interval !== normalized) {
+      updateNodeData(node.id, { ping_interval: normalized });
+    }
+  };
+
+  const handleDeleteWebsite = () => {
+    if (!node || node.type !== "website") return;
+
+    if (node.id.startsWith("temp-")) {
+      removeNode(node.id);
+      setSelectedNode(undefined);
+      return;
+    }
+
+    void deleteSiteNode(node.id, Number(node.id)).finally(() => {
+      setSelectedNode(undefined);
+    });
   };
 
   if (!node) {
@@ -91,26 +170,77 @@ export default function Inspector() {
       </div>
 
       <div className="mt-5 space-y-5">
-        {/* Название */}
-        <div className="space-y-2">
-          <label className="text-xs font-semibold uppercase tracking-wide text-slate-400">Название</label>
-          <input
-            value={form.title}
-            onChange={handleChange("title")}
-            className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-200"
-          />
-        </div>
+        {node.type === "website" ? (
+          <>
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-400">Название</label>
+              <input
+                ref={firstFieldRef}
+                value={form.title}
+                onChange={handleChange("title")}
+                placeholder="Например, Главная страница"
+                className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-200"
+              />
+            </div>
 
-        {/* Описание */}
-        <div className="space-y-2">
-          <label className="text-xs font-semibold uppercase tracking-wide text-slate-400">Описание</label>
-          <textarea
-            value={form.description}
-            onChange={handleChange("description")}
-            rows={3}
-            className="w-full resize-none rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-200"
-          />
-        </div>
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-400">URL</label>
+              <input
+                value={form.description}
+                onChange={handleChange("description")}
+                placeholder="https://example.com"
+                className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-200"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-400">Интервал опроса (сек)</label>
+              <input
+                type="number"
+                min={MIN_PING_INTERVAL}
+                max={MAX_PING_INTERVAL}
+                value={form.ping_interval}
+                onChange={handlePingIntervalChange}
+                onBlur={handlePingIntervalBlur}
+                className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-200"
+              />
+            </div>
+
+            <button
+              type="button"
+              className="w-full rounded-xl bg-rose-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-rose-700 focus:outline-none focus:ring-2 focus:ring-rose-200"
+              onClick={handleDeleteWebsite}
+            >
+              🗑 Удалить блок
+            </button>
+          </>
+        ) : node.type === "telegram" ? (
+          <div className="rounded-xl border border-emerald-100 bg-emerald-50/70 px-4 py-3 text-sm text-emerald-700 shadow-sm">
+            Этот Telegram-бот не имеет настраиваемых параметров. Просто подключите к нему нужные сайты.
+          </div>
+        ) : (
+          <>
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-400">Название</label>
+              <input
+                ref={firstFieldRef}
+                value={form.title}
+                onChange={handleChange("title")}
+                className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-200"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-400">Описание</label>
+              <textarea
+                value={form.description}
+                onChange={handleChange("description")}
+                rows={3}
+                className="w-full resize-none rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-200"
+              />
+            </div>
+          </>
+        )}
 
         {/* Статус */}
         <div className="space-y-2">
@@ -132,65 +262,6 @@ export default function Inspector() {
             ))}
           </div>
         </div>
-
-        {/* URL для website */}
-        {node.type === "website" && (
-          <>
-            {/* URL */}
-            <div className="space-y-2">
-              <label className="text-xs font-semibold uppercase text-slate-400">URL сайта</label>
-              <input
-                value={form.description}
-                onChange={handleChange("description")}
-                className="w-full rounded-xl border px-3 py-2 text-sm text-slate-700"
-              />
-            </div>
-
-            {/* Интервал */}
-            <div className="space-y-2">
-              <label className="text-xs font-semibold uppercase text-slate-400">Интервал (сек)</label>
-              <input
-                type="number"
-                min={5}
-                max={3600}
-                value={node.data.ping_interval ?? 30}
-                onChange={(e) => updateNodeData(node.id, { ping_interval: Number(e.target.value) })}
-                className="w-full rounded-xl border px-3 py-2 text-sm text-slate-700"
-              />
-            </div>
-
-            {/* Кнопки */}
-            <div className="flex gap-2 pt-4">
-              <button
-                className="flex-1 rounded-xl bg-sky-600 px-4 py-2 text-white"
-                onClick={async () => {
-                  const saved = await useFlowStore.getState().saveSite(node);
-                  if (saved && saved.id) {
-                    useFlowStore.setState({ selectedNodeId: String(saved.id) });
-                  }
-                }}
-              >
-                💾 Сохранить
-              </button>
-              <button
-                className="flex-1 rounded-xl bg-rose-600 px-4 py-2 text-white"
-                onClick={() => {
-                  if (node.id.startsWith("temp-")) {
-                    // удалить только локально
-                    useFlowStore.setState((state) => ({
-                      nodes: state.nodes.filter((n) => n.id !== node.id),
-                    }));
-                  } else {
-                    // удалить и на сервере, и локально
-                    useFlowStore.getState().deleteSiteNode(node.id, Number(node.id));
-                  }
-                }}
-              >
-                🗑 Удалить
-              </button>
-            </div>
-          </>
-        )}
 
         {/* Метаданные read-only */}
         {node.data.metadata && node.data.metadata.length > 0 && (

--- a/src/flow/FlowCanvas.tsx
+++ b/src/flow/FlowCanvas.tsx
@@ -23,6 +23,7 @@ import { useShallow } from "zustand/react/shallow";
 import { NODE_LIBRARY } from "./library";
 import LLMNode from "./nodes/LLMNode";
 import MessengerNode from "./nodes/MessengerNode";
+import TelegramNode from "./nodes/TelegramNode";
 import WebsiteNode from "./nodes/WebsiteNode";
 import type { FlowNode } from "./nodes/types";
 import { useFlowStore } from "../state/store";
@@ -33,6 +34,7 @@ const nodeTypes = {
   website: WebsiteNode,
   llm: LLMNode,
   messenger: MessengerNode,
+  telegram: TelegramNode,
 };
 
 const EDGE_COLOR = "#38bdf8";
@@ -66,7 +68,7 @@ function CanvasInner() {
     setNodes,
     setEdges,
     setSelectedNode,
-    syncWebsiteNode,
+    createWebsiteNode,
   } = useFlowStore(
     useShallow((state) => ({
       nodes: state.nodes,
@@ -74,7 +76,7 @@ function CanvasInner() {
       setNodes: state.setNodes,
       setEdges: state.setEdges,
       setSelectedNode: state.setSelectedNode,
-      syncWebsiteNode: state.syncWebsiteNode,
+      createWebsiteNode: state.createWebsiteNode,
     }))
   );
 
@@ -141,8 +143,13 @@ function CanvasInner() {
         y: event.clientY,
       });
 
+      if (template.type === "website") {
+        void createWebsiteNode(position, template.data);
+        return;
+      }
+
       const newNode: FlowNode = {
-        id: `temp-${nanoid()}`, // 🔹 временный id (будет заменён на id из БД при saveSite)
+        id: `temp-${nanoid()}`,
         type: template.type,
         position,
         data: { ...template.data },
@@ -150,13 +157,8 @@ function CanvasInner() {
 
       setNodes((nds) => nds.concat(newNode));
       setSelectedNode(newNode.id);
-
-      // 🔹 Если узел — сайт, сразу синхронизируем с БД
-      if (newNode.type === "website") {
-        syncWebsiteNode(newNode);
-      }
     },
-    [reactFlow, setNodes, setSelectedNode, syncWebsiteNode]
+    [createWebsiteNode, reactFlow, setNodes, setSelectedNode]
   );
 
   const backgroundGap = useMemo(() => ({ x: 40, y: 40 }), []);

--- a/src/flow/library.ts
+++ b/src/flow/library.ts
@@ -1,4 +1,9 @@
-import type { BaseNodeData, BlockVariant } from "./nodes/types";
+import {
+  DEFAULT_PING_INTERVAL,
+  buildWebsiteMetadata,
+  type BaseNodeData,
+  type BlockVariant,
+} from "./nodes/types";
 
 export type LibraryCategory = "Источники" | "Логика" | "Доставка";
 
@@ -15,14 +20,16 @@ export const NODE_LIBRARY: LibraryNodeTemplate[] = [
     type: "website",
     category: "Источники",
     data: {
-      title: "Мониторинг сайта",
+      title: "Пингер сайта",
       emoji: "🌐",
-      description: "Проверяет доступность страницы каждые N минут",
+      description: "https://example.com",
       status: "idle",
-      metadata: [
-        { label: "URL", value: "https://pingtower.com" },
-        { label: "Период", value: "60 сек" },
-      ],
+      ping_interval: DEFAULT_PING_INTERVAL,
+      metadata: buildWebsiteMetadata({
+        title: "Пингер сайта",
+        description: "https://example.com",
+        ping_interval: DEFAULT_PING_INTERVAL,
+      }),
     },
   },
   {
@@ -52,6 +59,21 @@ export const NODE_LIBRARY: LibraryNodeTemplate[] = [
       metadata: [
         { label: "Канал", value: "@pingtower" },
         { label: "Формат", value: "Markdown" },
+      ],
+    },
+  },
+  {
+    templateId: "telegram-official-bot",
+    type: "telegram",
+    category: "Доставка",
+    data: {
+      title: "Telegram бот",
+      emoji: "🤖",
+      description: "@T1_InTeam_bot",
+      status: "idle",
+      metadata: [
+        { label: "Тег", value: "@T1_InTeam_bot" },
+        { label: "Статус", value: "Готов к приёму" },
       ],
     },
   },

--- a/src/flow/nodes/BaseBlock.tsx
+++ b/src/flow/nodes/BaseBlock.tsx
@@ -31,6 +31,12 @@ const variantStyles: Record<
     accent: "bg-emerald-500/10 text-emerald-600 border-emerald-200",
     size: { width: 210, height: 160, radius: "rounded-2xl" },
   },
+  telegram: {
+    border: "border-emerald-200",
+    glow: "shadow-[0_10px_32px_-18px_rgba(16,185,129,0.55)]",
+    accent: "bg-emerald-500/10 text-emerald-600 border-emerald-200",
+    size: { width: 210, height: 160, radius: "rounded-2xl" },
+  },
 };
 
 const statusStyles: Record<

--- a/src/flow/nodes/TelegramNode.tsx
+++ b/src/flow/nodes/TelegramNode.tsx
@@ -1,0 +1,8 @@
+import type { NodeProps } from "reactflow";
+
+import BaseBlock from "./BaseBlock";
+import type { BaseNodeData } from "./types";
+
+export default function TelegramNode(props: NodeProps<BaseNodeData>) {
+  return <BaseBlock {...props} variant="telegram" />;
+}

--- a/src/flow/nodes/WebsiteNode.tsx
+++ b/src/flow/nodes/WebsiteNode.tsx
@@ -1,15 +1,112 @@
-import type { NodeProps } from "reactflow";
+import { type MouseEventHandler } from "react";
+import { NodeToolbar, type NodeProps } from "reactflow";
+import { useFlowStore } from "../../state/store";
 import BaseBlock from "./BaseBlock";
-import type { BaseNodeData } from "./types";
+import {
+  buildWebsiteMetadata,
+  DEFAULT_PING_INTERVAL,
+  MAX_PING_INTERVAL,
+  MIN_PING_INTERVAL,
+  normalizePingInterval,
+  type BaseNodeData,
+} from "./types";
 
 export default function WebsiteNode(props: NodeProps<BaseNodeData>) {
-  const { data } = props;
+  const { data, id, selected } = props;
 
-  // 🔹 добавляем ping_interval в metadata, если его нет
-  const metadata = [
-    ...(data.metadata ?? []),
-    { label: "PING INTERVAL", value: `${data.ping_interval ?? 30} сек` },
-  ];
+  const setSelectedNode = useFlowStore((state) => state.setSelectedNode);
+  const updateNodeData = useFlowStore((state) => state.updateNodeData);
+  const deleteSiteNode = useFlowStore((state) => state.deleteSiteNode);
+  const removeNode = useFlowStore((state) => state.removeNode);
 
-  return <BaseBlock {...props} variant="website" data={{ ...data, metadata }} />;
+  const metadata = data.metadata ?? buildWebsiteMetadata(data);
+
+  const handleEditClick: MouseEventHandler<HTMLButtonElement> = (event) => {
+    event.stopPropagation();
+    setSelectedNode(id);
+
+    const state = useFlowStore.getState();
+    const current = state.nodes.find((node) => node.id === id);
+    if (!current || current.type !== "website") return;
+
+    const currentUrl = current.data.description ?? "";
+    const nextUrl = window.prompt("Введите URL сайта", currentUrl);
+    if (nextUrl === null) return;
+    const trimmedUrl = nextUrl.trim();
+
+    const currentName = current.data.title ?? "";
+    const nextName = window.prompt("Введите название сайта", currentName);
+    if (nextName === null) return;
+    const trimmedName = nextName.trim();
+
+    const currentInterval = current.data.ping_interval ?? DEFAULT_PING_INTERVAL;
+    const nextIntervalRaw = window.prompt(
+      "Введите интервал опроса (сек)",
+      String(currentInterval)
+    );
+    if (nextIntervalRaw === null) return;
+
+    const normalizedInterval = normalizePingInterval(nextIntervalRaw);
+    if (!normalizedInterval) {
+      window.alert(
+        `Интервал должен быть положительным числом от ${MIN_PING_INTERVAL} до ${MAX_PING_INTERVAL}`
+      );
+      return;
+    }
+
+    const updates: Partial<BaseNodeData> = {};
+    if (trimmedUrl !== currentUrl && trimmedUrl !== "") {
+      updates.description = trimmedUrl;
+    }
+    if (trimmedName !== currentName && trimmedName !== "") {
+      updates.title = trimmedName;
+    }
+    if (normalizedInterval !== currentInterval) {
+      updates.ping_interval = normalizedInterval;
+    }
+
+    if (Object.keys(updates).length > 0) {
+      updateNodeData(id, updates);
+    }
+  };
+
+  const handleDeleteClick: MouseEventHandler<HTMLButtonElement> = (event) => {
+    event.stopPropagation();
+    setSelectedNode(undefined);
+
+    const state = useFlowStore.getState();
+    const current = state.nodes.find((node) => node.id === id);
+    if (!current || current.type !== "website") return;
+
+    if (current.id.startsWith("temp-")) {
+      removeNode(current.id);
+      return;
+    }
+
+    void deleteSiteNode(current.id, Number(current.id));
+  };
+
+  return (
+    <>
+      <NodeToolbar isVisible={selected} position="top">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-600 shadow-sm transition hover:border-sky-300 hover:text-sky-600"
+            onClick={handleEditClick}
+          >
+            ✏️ Изменить
+          </button>
+          <button
+            type="button"
+            className="rounded-full border border-rose-200 bg-white px-3 py-1 text-xs font-semibold text-rose-600 shadow-sm transition hover:border-rose-300 hover:text-rose-600"
+            onClick={handleDeleteClick}
+          >
+            🗑 Удалить
+          </button>
+        </div>
+      </NodeToolbar>
+      <BaseBlock {...props} variant="website" data={{ ...data, metadata }} />
+    </>
+  );
 }

--- a/src/flow/nodes/types.ts
+++ b/src/flow/nodes/types.ts
@@ -1,8 +1,7 @@
-import type { Node, Edge } from "reactflow";
-import type { BaseNodeData } from "../flow/nodes/types";
+import type { Edge, Node } from "reactflow";
 
 // Варианты блоков
-export type BlockVariant = "website" | "llm" | "messenger";
+export type BlockVariant = "website" | "llm" | "messenger" | "telegram";
 
 // Статусы нод
 export type NodeStatus = "idle" | "running" | "success" | "error";
@@ -14,14 +13,48 @@ export type NodeMetadataEntry = {
 };
 
 // Базовые данные ноды
+export const DEFAULT_PING_INTERVAL = 30;
+export const MIN_PING_INTERVAL = 1;
+export const MAX_PING_INTERVAL = 3600;
+
 export type BaseNodeData = {
   title?: string;
   description?: string;
   emoji?: string;
   status?: NodeStatus;
   metadata?: NodeMetadataEntry[];
-  ping_interval?: number; // 🔹 новое поле
+  ping_interval?: number;
+  com?: Record<string, unknown> | null;
 };
+
+export function normalizePingInterval(value: string): number | undefined {
+  const numeric = Number(value.trim());
+  if (!Number.isFinite(numeric)) return undefined;
+  if (numeric <= 0) return undefined;
+  return Math.min(MAX_PING_INTERVAL, Math.max(MIN_PING_INTERVAL, Math.round(numeric)));
+}
+
+export function buildWebsiteMetadata(data: BaseNodeData): NodeMetadataEntry[] {
+  const interval = data.ping_interval ?? DEFAULT_PING_INTERVAL;
+
+  const entries: NodeMetadataEntry[] = [
+    { label: "URL", value: data.description ?? "—" },
+    { label: "Название", value: data.title ?? "Без имени" },
+    { label: "Интервал", value: `${interval} сек` },
+  ];
+
+  const telegramStatusRaw =
+    data.com && typeof data.com === "object" && "tg" in data.com
+      ? (data.com as Record<string, unknown>).tg
+      : undefined;
+
+  if (telegramStatusRaw !== undefined) {
+    const isEnabled = Number(telegramStatusRaw) === 1 || telegramStatusRaw === true;
+    entries.push({ label: "Telegram", value: isEnabled ? "Подключен" : "Отключен" });
+  }
+
+  return entries;
+}
 
 // FlowNode
 export type FlowNode = Node<BaseNodeData>;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,8 +1,16 @@
 // src/lib/api.ts
+export type SiteRecord = {
+  id: number;
+  url: string;
+  name: string;
+  ping_interval: number;
+  com?: Record<string, unknown> | null;
+};
+
 export async function fetchSites() {
   const res = await fetch("http://localhost:8000/sites");
   if (!res.ok) throw new Error("Ошибка при загрузке сайтов");
-  return res.json() as Promise<{ id: number; url: string; name: string; ping_interval: number }[]>;
+  return res.json() as Promise<SiteRecord[]>;
 }
 
 export async function createSite(url: string, name: string, ping_interval = 30) {
@@ -12,7 +20,7 @@ export async function createSite(url: string, name: string, ping_interval = 30) 
     body: JSON.stringify({ url, name, ping_interval }),
   });
   if (!res.ok) throw new Error("Ошибка при создании сайта");
-  return res.json() as Promise<{ id: number; url: string; name: string; ping_interval: number }>;
+  return res.json() as Promise<SiteRecord>;
 }
 
 export async function updateSite(id: number, data: { url: string; name: string; ping_interval: number }) {
@@ -22,11 +30,21 @@ export async function updateSite(id: number, data: { url: string; name: string; 
     body: JSON.stringify(data),
   });
   if (!res.ok) throw new Error("Ошибка при обновлении сайта");
-  return res.json();
+  return res.json() as Promise<SiteRecord>;
 }
 
 export async function deleteSite(id: number) {
   const res = await fetch(`http://localhost:8000/sites/${id}`, { method: "DELETE" });
   if (!res.ok) throw new Error("Ошибка при удалении сайта");
   return true;
+}
+
+export async function patchSiteParams(id: number, params: { com?: Record<string, unknown> | null }) {
+  const res = await fetch(`http://localhost:8000/sites/${id}/params`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(params),
+  });
+  if (!res.ok) throw new Error("Ошибка при обновлении параметров сайта");
+  return res.json() as Promise<SiteRecord>;
 }

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,9 +1,79 @@
 import { create } from "zustand";
-import { fetchSites, createSite, updateSite, deleteSite } from "../lib/api";
-import type { FlowNode, BaseNodeData } from "../flow/nodes/types";
-import type { Edge } from "reactflow";
+import {
+  fetchSites,
+  createSite,
+  updateSite,
+  deleteSite,
+  patchSiteParams,
+  type SiteRecord,
+} from "../lib/api";
+import {
+  type BaseNodeData,
+  type FlowNode,
+  buildWebsiteMetadata,
+  DEFAULT_PING_INTERVAL,
+  MAX_PING_INTERVAL,
+  MIN_PING_INTERVAL,
+  normalizePingInterval,
+} from "../flow/nodes/types";
+import type { Edge, XYPosition } from "reactflow";
 
 export type NodeStatus = "idle" | "running" | "success" | "error";
+
+const websiteSyncTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+const cancelWebsiteSyncTimer = (nodeId: string) => {
+  const timer = websiteSyncTimers.get(nodeId);
+  if (timer) {
+    clearTimeout(timer);
+    websiteSyncTimers.delete(nodeId);
+  }
+};
+
+const parseComValue = (value: SiteRecord["com"]): Record<string, unknown> | null => {
+  if (!value) return null;
+  if (typeof value === "string") {
+    try {
+      return JSON.parse(value) as Record<string, unknown>;
+    } catch (err) {
+      console.warn("[FlowStore] Не удалось распарсить поле com", err);
+      return null;
+    }
+  }
+
+  if (typeof value === "object") {
+    return value as Record<string, unknown>;
+  }
+
+  return null;
+};
+
+const isTelegramLinked = (data?: BaseNodeData): boolean => {
+  if (!data?.com || typeof data.com !== "object") return false;
+  const raw = (data.com as Record<string, unknown>).tg;
+  return Number(raw) === 1 || raw === true;
+};
+
+const buildTelegramCom = (
+  current: BaseNodeData["com"],
+  enabled: boolean
+): Record<string, unknown> => {
+  const base =
+    current && typeof current === "object"
+      ? { ...(current as Record<string, unknown>) }
+      : ({} as Record<string, unknown>);
+  base.tg = enabled ? 1 : 0;
+  return base;
+};
+
+const isWebsiteConnectedToTelegram = (siteId: string, nodes: FlowNode[], edges: Edge[]): boolean => {
+  const nodeMap = new Map(nodes.map((node) => [node.id, node]));
+  return edges.some((edge) => {
+    if (edge.source !== siteId) return false;
+    const targetNode = nodeMap.get(edge.target);
+    return targetNode?.type === "telegram";
+  });
+};
 
 type FlowStore = {
   flowName: string;
@@ -13,15 +83,18 @@ type FlowStore = {
   edges: Edge[];
   setNodes: (updater: FlowNode[] | ((nodes: FlowNode[]) => FlowNode[])) => void;
   setEdges: (updater: Edge[] | ((edges: Edge[]) => Edge[])) => void;
+  setWebsiteTelegramLink: (siteId: string, enabled: boolean) => Promise<void>;
 
   selectedNodeId?: string;
   setSelectedNode: (id?: string) => void;
 
   initFromDb: () => Promise<void>;
-  saveSite: (node: FlowNode) => Promise<{ id: number; url: string; name: string; ping_interval: number } | undefined>;
+  createWebsiteNode: (position: XYPosition, template: BaseNodeData) => Promise<FlowNode | undefined>;
+  saveSite: (node: FlowNode) => Promise<SiteRecord | undefined>;
   deleteSiteNode: (nodeId: string, siteId: number) => Promise<void>;
-  syncWebsiteNode: (node: FlowNode) => Promise<{ id: number; url: string; name: string; ping_interval: number } | undefined>;
+  syncWebsiteNode: (node: FlowNode) => Promise<SiteRecord | undefined>;
   updateNodeData: (id: string, data: Partial<BaseNodeData>) => void;
+  removeNode: (nodeId: string) => void;
 
   runFlow: () => void;
   stopFlow: () => void;
@@ -44,11 +117,48 @@ export const useFlowStore = create<FlowStore>((set, get) => ({
       nodes: typeof updater === "function" ? updater(state.nodes) : updater,
       isDirty: true,
     })),
-  setEdges: (updater) =>
-    set((state) => ({
-      edges: typeof updater === "function" ? updater(state.edges) : updater,
-      isDirty: true,
-    })),
+  setEdges: (updater) => {
+    const updates: { siteId: string; enabled: boolean }[] = [];
+
+    set((state) => {
+      const nextEdges =
+        typeof updater === "function" ? updater(state.edges) : updater;
+
+      const nodeMap = new Map(state.nodes.map((node) => [node.id, node]));
+      const websiteFlags = new Map<string, boolean>();
+
+      state.nodes.forEach((node) => {
+        if (node.type === "website") {
+          websiteFlags.set(node.id, false);
+        }
+      });
+
+      nextEdges.forEach((edge) => {
+        const sourceNode = nodeMap.get(edge.source);
+        const targetNode = nodeMap.get(edge.target);
+
+        if (sourceNode?.type === "website" && targetNode?.type === "telegram") {
+          websiteFlags.set(sourceNode.id, true);
+        }
+      });
+
+      websiteFlags.forEach((enabled, siteId) => {
+        const node = nodeMap.get(siteId);
+        if (!node) return;
+
+        const currentlyLinked = isTelegramLinked(node.data);
+        if (enabled !== currentlyLinked) {
+          updates.push({ siteId, enabled });
+        }
+      });
+
+      return { edges: nextEdges, isDirty: true };
+    });
+
+    updates.forEach(({ siteId, enabled }) => {
+      void get().setWebsiteTelegramLink(siteId, enabled);
+    });
+  },
 
   selectedNodeId: undefined,
   setSelectedNode: (id) => set({ selectedNodeId: id }),
@@ -57,26 +167,107 @@ export const useFlowStore = create<FlowStore>((set, get) => ({
   initFromDb: async () => {
     try {
       const sites = await fetchSites();
-      const nodes: FlowNode[] = sites.map((site) => ({
-        id: String(site.id),
-        type: "website",
-        position: { x: Math.random() * 400, y: Math.random() * 400 },
-        data: {
-          title: site.name,
-          description: site.url,
-          emoji: "🌐",
-          status: "idle" as NodeStatus,
-          ping_interval: site.ping_interval ?? 30,
-          metadata: [
-            { label: "URL", value: site.url },
-            { label: "Имя", value: site.name },
-            { label: "Интервал", value: site.ping_interval?.toString() ?? "30" },
-          ],
-        },
-      }));
+      const nodes: FlowNode[] = sites.map((site) => {
+        const com = parseComValue(site.com);
+        const pingInterval = site.ping_interval ?? DEFAULT_PING_INTERVAL;
+
+        return {
+          id: String(site.id),
+          type: "website",
+          position: { x: Math.random() * 400, y: Math.random() * 400 },
+          data: {
+            title: site.name,
+            description: site.url,
+            emoji: "🌐",
+            status: "idle" as NodeStatus,
+            ping_interval: pingInterval,
+            com,
+            metadata: buildWebsiteMetadata({
+              title: site.name,
+              description: site.url,
+              ping_interval: pingInterval,
+              com,
+            }),
+          },
+        };
+      });
       set({ nodes, isDirty: false });
     } catch (err) {
       console.error("[FlowStore] Ошибка загрузки сайтов:", err);
+    }
+  },
+
+  createWebsiteNode: async (position, template) => {
+    if (typeof window === "undefined") return;
+
+    const defaultUrl = template.description?.trim() || "https://example.com";
+    const defaultName = template.title?.trim() || "Новый сайт";
+    const defaultInterval = template.ping_interval ?? DEFAULT_PING_INTERVAL;
+
+    const urlInput = window.prompt("Введите URL сайта", defaultUrl);
+    if (urlInput === null) return;
+    const url = urlInput.trim();
+    if (!url) {
+      window.alert("URL не может быть пустым");
+      return;
+    }
+
+    const nameInput = window.prompt("Введите название сайта", defaultName);
+    if (nameInput === null) return;
+    const name = nameInput.trim();
+    if (!name) {
+      window.alert("Название не может быть пустым");
+      return;
+    }
+
+    const intervalInput = window.prompt(
+      "Введите интервал опроса (сек)",
+      String(defaultInterval)
+    );
+    if (intervalInput === null) return;
+
+    const normalizedInterval = normalizePingInterval(intervalInput);
+    if (!normalizedInterval) {
+      window.alert(
+        `Интервал должен быть положительным числом от ${MIN_PING_INTERVAL} до ${MAX_PING_INTERVAL}`
+      );
+      return;
+    }
+
+    try {
+      const saved = await createSite(url, name, normalizedInterval);
+      const com = parseComValue(saved.com) ?? buildTelegramCom(template.com, false);
+
+      const node: FlowNode = {
+        id: String(saved.id),
+        type: "website",
+        position,
+        data: {
+          emoji: template.emoji ?? "🌐",
+          status: template.status ?? "idle",
+          title: saved.name,
+          description: saved.url,
+          ping_interval: saved.ping_interval ?? normalizedInterval,
+          com,
+          metadata: buildWebsiteMetadata({
+            title: saved.name,
+            description: saved.url,
+            ping_interval: saved.ping_interval ?? normalizedInterval,
+            com,
+          }),
+        },
+      };
+
+      set((state) => ({
+        nodes: state.nodes.concat(node),
+        selectedNodeId: node.id,
+        isDirty: false,
+        lastSavedAt: new Date(),
+      }));
+
+      return node;
+    } catch (err) {
+      console.error("[FlowStore] Ошибка создания сайта:", err);
     }
   },
 
@@ -87,11 +278,12 @@ export const useFlowStore = create<FlowStore>((set, get) => ({
     try {
       const url = node.data.description || "";
       const name = node.data.title || "Без имени";
-      const ping_interval = node.data.ping_interval ?? 30;
+      const ping_interval = node.data.ping_interval ?? DEFAULT_PING_INTERVAL;
 
       const saved = node.id.startsWith("temp-")
         ? await createSite(url, name, ping_interval)
         : await updateSite(Number(node.id), { url, name, ping_interval });
+      const com = parseComValue(saved.com) ?? node.data.com ?? null;
 
       set((state) => ({
         nodes: state.nodes.map((n) =>
@@ -104,6 +296,13 @@ export const useFlowStore = create<FlowStore>((set, get) => ({
                   title: saved.name,
                   description: saved.url,
                   ping_interval: saved.ping_interval,
+                  com,
+                  metadata: buildWebsiteMetadata({
+                    title: saved.name,
+                    description: saved.url,
+                    ping_interval: saved.ping_interval,
+                    com,
+                  }),
                 },
               }
             : n
@@ -123,12 +322,14 @@ export const useFlowStore = create<FlowStore>((set, get) => ({
     try {
       await deleteSite(Number(siteId));
     } catch (err) {
-      console.warn("[FlowStore] Сервер не нашёл сайт, удаляем только локально", { nodeId, siteId });
+      console.warn("[FlowStore] Сервер не нашёл сайт, удаляем только локально", { nodeId, siteId, err });
     } finally {
+      cancelWebsiteSyncTimer(nodeId);
       set((state) => ({
         nodes: state.nodes.filter((n) => n.id !== nodeId),
         isDirty: true,
       }));
+      get().setEdges((edges) => edges.filter((edge) => edge.source !== nodeId && edge.target !== nodeId));
     }
   },
 
@@ -139,14 +340,117 @@ export const useFlowStore = create<FlowStore>((set, get) => ({
     }
   },
 
+  setWebsiteTelegramLink: async (siteId, enabled) => {
+    const state = get();
+    const node = state.nodes.find((candidate) => candidate.id === siteId && candidate.type === "website");
+    if (!node) return;
+
+    const numericId = Number(siteId);
+    if (!Number.isFinite(numericId)) return;
+
+    const desiredState = isWebsiteConnectedToTelegram(siteId, state.nodes, state.edges);
+    if (enabled !== desiredState) {
+      enabled = desiredState;
+    }
+
+    const currentlyLinked = isTelegramLinked(node.data);
+    if (enabled === currentlyLinked) return;
+
+    const nextCom = buildTelegramCom(node.data.com, enabled);
+
+    try {
+      const saved = await patchSiteParams(numericId, { com: nextCom });
+      const savedCom = parseComValue(saved.com) ?? nextCom;
+
+      set((innerState) => ({
+        nodes: innerState.nodes.map((candidate) =>
+          candidate.id === siteId && candidate.type === "website"
+            ? {
+                ...candidate,
+                data: {
+                  ...candidate.data,
+                  com: savedCom,
+                  metadata: buildWebsiteMetadata({
+                    ...candidate.data,
+                    com: savedCom,
+                  }),
+                },
+              }
+            : candidate
+        ),
+        lastSavedAt: new Date(),
+      }));
+
+      const latest = get();
+      const shouldBeEnabledNow = isWebsiteConnectedToTelegram(siteId, latest.nodes, latest.edges);
+      const latestNode = latest.nodes.find(
+        (candidate) => candidate.id === siteId && candidate.type === "website"
+      );
+      const latestLinked = isTelegramLinked(latestNode?.data);
+
+      if (shouldBeEnabledNow !== latestLinked) {
+        void get().setWebsiteTelegramLink(siteId, shouldBeEnabledNow);
+      }
+    } catch (err) {
+      console.error("[FlowStore] Ошибка обновления привязки Telegram", {
+        siteId,
+        enabled,
+        err,
+      });
+    }
+  },
+
   // ✏️ обновить локально
-  updateNodeData: (id, data) =>
+  updateNodeData: (id, data) => {
+    let updatedNode: FlowNode | undefined;
+
     set((state) => ({
-      nodes: state.nodes.map((node) =>
-        node.id === id ? { ...node, data: { ...node.data, ...data } } : node
-      ),
+      nodes: state.nodes.map((node) => {
+        if (node.id !== id) return node;
+
+        const nextData: BaseNodeData = {
+          ...node.data,
+          ...data,
+        };
+
+        if (node.type === "website") {
+          nextData.metadata = buildWebsiteMetadata(nextData);
+        }
+
+        const nextNode = { ...node, data: nextData };
+        updatedNode = nextNode;
+        return nextNode;
+      }),
       isDirty: true,
-    })),
+    }));
+
+    const shouldSyncWebsite =
+      updatedNode?.type === "website" &&
+      ("title" in data || "description" in data || "ping_interval" in data);
+
+    if (updatedNode && shouldSyncWebsite) {
+      const existingTimer = websiteSyncTimers.get(updatedNode.id);
+      if (existingTimer) {
+        clearTimeout(existingTimer);
+      }
+
+      const timer = setTimeout(() => {
+        void get().syncWebsiteNode(updatedNode!);
+        websiteSyncTimers.delete(updatedNode!.id);
+      }, 500);
+
+      websiteSyncTimers.set(updatedNode.id, timer);
+    }
+  },
+
+  removeNode: (nodeId) => {
+    cancelWebsiteSyncTimer(nodeId);
+    set((state) => ({
+      nodes: state.nodes.filter((node) => node.id !== nodeId),
+      isDirty: true,
+    }));
+    get().setEdges((edges) => edges.filter((edge) => edge.source !== nodeId && edge.target !== nodeId));
+  },
 
   runFlow: () => set({ isRunning: true, lastRunAt: new Date() }),
   stopFlow: () => set({ isRunning: false }),

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -3,8 +3,9 @@ import type { Connection, Edge } from "reactflow";
 import type { BlockVariant, FlowNode } from "../flow/nodes/types";
 
 const forbiddenConnections: Partial<Record<BlockVariant, BlockVariant[]>> = {
-  llm: ["website"],
-  messenger: ["llm", "website"],
+  llm: ["website", "telegram"],
+  messenger: ["llm", "website", "telegram"],
+  telegram: ["llm", "website", "messenger"],
 };
 
 type ConnectionContext = {


### PR DESCRIPTION
## Summary
- add a dedicated Telegram bot block with styling, palette entry, and inspector messaging
- extend website metadata/storage to track Telegram linkage and expose a PATCH helper for com updates
- recompute website com.tg when edges to Telegram bots are created or removed, updating backend state accordingly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfdfbd49c8832bbd33be19aaa392e4